### PR TITLE
feat: add HQ/country filter to sidebar and mobile modal

### DIFF
--- a/assets/ts/filter.ts
+++ b/assets/ts/filter.ts
@@ -8,6 +8,7 @@ export interface FilterState {
 	showFreemiumOnly: boolean
 	showFreeOnly: boolean
 	selectedPlatforms: string[]
+	selectedHQ: string[]
 	selectedCompliance: string[]
 	selectedAuthentication: string[]
 	signupIsOpenOnly: boolean
@@ -24,6 +25,7 @@ export class FilterEngine {
 		showFreemiumOnly: false,
 		showFreeOnly: false,
 		selectedPlatforms: [],
+		selectedHQ: [],
 		selectedCompliance: [],
 		selectedAuthentication: [],
 		signupIsOpenOnly: false,
@@ -96,6 +98,7 @@ export class FilterEngine {
 				this.matchesFreemium(row) &&
 				this.matchesFree(row) &&
 				this.matchesPlatforms(row) &&
+				this.matchesHQ(row) &&
 				this.matchesCompliance(row) &&
 				this.matchesAuthentication(row) &&
 				this.matchesSignup(row)
@@ -183,6 +186,12 @@ export class FilterEngine {
 		return this.state.selectedPlatforms.every((p) => platforms.includes(p))
 	}
 
+	private matchesHQ(row: HTMLElement): boolean {
+		if (this.state.selectedHQ.length === 0) return true
+		const hqs = (row.dataset.hq || '').split(',').filter(Boolean)
+		return this.state.selectedHQ.some((h) => hqs.includes(h))
+	}
+
 	private matchesCompliance(row: HTMLElement): boolean {
 		if (this.state.selectedCompliance.length === 0) return true
 		const compliance = (row.dataset.compliance || '').split(',').filter(Boolean)
@@ -241,14 +250,26 @@ export class FilterEngine {
 		this.updateVisibleCount()
 
 		const matchingSet = new Set(this.matchingRows)
-		const platformCheckboxes = document.querySelectorAll<HTMLElement>('[data-platform-count]')
-		for (const el of platformCheckboxes) {
+		const platformCountEls = document.querySelectorAll<HTMLElement>('[data-platform-count]')
+		for (const el of platformCountEls) {
 			const platform = el.dataset.platformCount || ''
 			let count = 0
 			for (const row of this.rows) {
 				if (!matchingSet.has(row)) continue
 				const platforms = (row.dataset.platforms || '').split(',').filter(Boolean)
 				if (platforms.includes(platform)) count++
+			}
+			el.textContent = String(count)
+		}
+
+		const hqCountEls = document.querySelectorAll<HTMLElement>('[data-hq-count]')
+		for (const el of hqCountEls) {
+			const hq = el.dataset.hqCount || ''
+			let count = 0
+			for (const row of this.rows) {
+				if (!matchingSet.has(row)) continue
+				const hqs = (row.dataset.hq || '').split(',').filter(Boolean)
+				if (hqs.includes(hq)) count++
 			}
 			el.textContent = String(count)
 		}

--- a/assets/ts/main.ts
+++ b/assets/ts/main.ts
@@ -238,7 +238,6 @@ function initHomePage(productList: HTMLElement): void {
 	const platformCheckboxes = Array.from(document.querySelectorAll<HTMLInputElement>('[data-platform-checkbox]'))
 	for (const cb of platformCheckboxes) {
 		cb.addEventListener('change', () => {
-			// Sync all checkboxes with the same platform value (sidebar ↔ modal)
 			const val = cb.dataset.platformCheckbox!
 			for (const other of platformCheckboxes) {
 				if (other.dataset.platformCheckbox === val) other.checked = cb.checked
@@ -246,6 +245,20 @@ function initHomePage(productList: HTMLElement): void {
 			const seen = new Set<string>()
 			const selected = platformCheckboxes.filter((c) => c.checked).map((c) => c.dataset.platformCheckbox!).filter((v) => seen.has(v) ? false : seen.add(v) && true)
 			engine.setState({ selectedPlatforms: selected })
+		})
+	}
+
+	// HQ checkboxes (sidebar + mobile modal share same data-hq-checkbox attr)
+	const hqCheckboxes = Array.from(document.querySelectorAll<HTMLInputElement>('[data-hq-checkbox]'))
+	for (const cb of hqCheckboxes) {
+		cb.addEventListener('change', () => {
+			const val = cb.dataset.hqCheckbox!
+			for (const other of hqCheckboxes) {
+				if (other.dataset.hqCheckbox === val) other.checked = cb.checked
+			}
+			const seen = new Set<string>()
+			const selected = hqCheckboxes.filter((c) => c.checked).map((c) => c.dataset.hqCheckbox!).filter((v) => seen.has(v) ? false : seen.add(v) && true)
+			engine.setState({ selectedHQ: selected })
 		})
 	}
 
@@ -259,9 +272,10 @@ function initHomePage(productList: HTMLElement): void {
 	const resetBtns = Array.from(document.querySelectorAll<HTMLButtonElement>('#reset-filters, #empty-state-reset'))
 	for (const btn of resetBtns) {
 		btn.addEventListener('click', () => {
-			engine.setState({ category: '', searchTerm: '', showOpenSource: false, showProprietary: false, showDiscontinuedOnly: false, showFreeTrialOnly: false, showFreemiumOnly: false, showFreeOnly: false, selectedPlatforms: [], selectedCompliance: [], selectedAuthentication: [], signupIsOpenOnly: false })
+			engine.setState({ category: '', searchTerm: '', showOpenSource: false, showProprietary: false, showDiscontinuedOnly: false, showFreeTrialOnly: false, showFreemiumOnly: false, showFreeOnly: false, selectedPlatforms: [], selectedHQ: [], selectedCompliance: [], selectedAuthentication: [], signupIsOpenOnly: false })
 			if (searchInput) searchInput.value = ''
 			for (const cb of platformCheckboxes) cb.checked = false
+			for (const cb of hqCheckboxes) cb.checked = false
 			syncTypePills(typePills, engine)
 		})
 	}
@@ -273,7 +287,7 @@ function initHomePage(productList: HTMLElement): void {
 	function updateMobileFilterBadge(): void {
 		if (!mobileFilterBadge) return
 		const s = engine.getState()
-		const count = [s.showOpenSource, s.showFreeOnly, s.showFreeTrialOnly, s.showProprietary, s.showDiscontinuedOnly, s.signupIsOpenOnly].filter(Boolean).length + s.selectedPlatforms.length
+		const count = [s.showOpenSource, s.showFreeOnly, s.showFreeTrialOnly, s.showProprietary, s.showDiscontinuedOnly, s.signupIsOpenOnly].filter(Boolean).length + s.selectedPlatforms.length + s.selectedHQ.length
 		mobileFilterBadge.textContent = String(count)
 		mobileFilterBadge.classList.toggle('hidden', count === 0)
 	}
@@ -293,9 +307,10 @@ function initHomePage(productList: HTMLElement): void {
 	document.querySelector('#mobile-filter-close')?.addEventListener('click', closeFilterModal)
 	document.querySelector('#mobile-filter-done')?.addEventListener('click', closeFilterModal)
 	document.querySelector('#mobile-filter-reset')?.addEventListener('click', () => {
-		engine.setState({ category: '', searchTerm: '', showOpenSource: false, showProprietary: false, showDiscontinuedOnly: false, showFreeTrialOnly: false, showFreemiumOnly: false, showFreeOnly: false, selectedPlatforms: [], selectedCompliance: [], selectedAuthentication: [], signupIsOpenOnly: false })
+		engine.setState({ category: '', searchTerm: '', showOpenSource: false, showProprietary: false, showDiscontinuedOnly: false, showFreeTrialOnly: false, showFreemiumOnly: false, showFreeOnly: false, selectedPlatforms: [], selectedHQ: [], selectedCompliance: [], selectedAuthentication: [], signupIsOpenOnly: false })
 		if (searchInput) searchInput.value = ''
 		for (const cb of platformCheckboxes) cb.checked = false
+		for (const cb of hqCheckboxes) cb.checked = false
 		syncTypePills(typePills, engine)
 		updateMobileFilterBadge()
 	})
@@ -328,6 +343,17 @@ function initHomePage(productList: HTMLElement): void {
 				},
 			})
 		}
+		for (const hq of s.selectedHQ) {
+			const h = hq
+			const label = h.split(' ').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+			pills.push({
+				label,
+				onRemove: () => {
+					engine.setState({ selectedHQ: engine.getState().selectedHQ.filter((x) => x !== h) })
+					for (const cb of hqCheckboxes) if (cb.dataset.hqCheckbox === h) cb.checked = false
+				},
+			})
+		}
 
 		if (pills.length === 0) {
 			container.innerHTML = ''
@@ -354,8 +380,9 @@ function initHomePage(productList: HTMLElement): void {
 			clearBtn.className = 'inline-flex items-center px-2.5 py-1 text-xs font-medium text-neutral-400 hover:text-neutral-700 transition-colors'
 			clearBtn.textContent = 'Clear all'
 			clearBtn.addEventListener('click', () => {
-				engine.setState({ showOpenSource: false, showFreeOnly: false, showFreeTrialOnly: false, showProprietary: false, showDiscontinuedOnly: false, showFreemiumOnly: false, selectedPlatforms: [], selectedCompliance: [], selectedAuthentication: [], signupIsOpenOnly: false })
+				engine.setState({ showOpenSource: false, showFreeOnly: false, showFreeTrialOnly: false, showProprietary: false, showDiscontinuedOnly: false, showFreemiumOnly: false, selectedPlatforms: [], selectedHQ: [], selectedCompliance: [], selectedAuthentication: [], signupIsOpenOnly: false })
 				for (const cb of platformCheckboxes) cb.checked = false
+				for (const cb of hqCheckboxes) cb.checked = false
 				syncTypePills(typePills, engine)
 			})
 			container.appendChild(clearBtn)
@@ -366,7 +393,7 @@ function initHomePage(productList: HTMLElement): void {
 	engine.onChange(() => {
 		renderActiveFilters()
 		const s = engine.getState()
-		const isDefault = !s.searchTerm && !s.showOpenSource && !s.showFreeOnly && !s.showProprietary && !s.showDiscontinuedOnly && !s.showFreeTrialOnly && !s.showFreemiumOnly && s.selectedPlatforms.length === 0 && !s.signupIsOpenOnly
+		const isDefault = !s.searchTerm && !s.showOpenSource && !s.showFreeOnly && !s.showProprietary && !s.showDiscontinuedOnly && !s.showFreeTrialOnly && !s.showFreemiumOnly && s.selectedPlatforms.length === 0 && s.selectedHQ.length === 0 && !s.signupIsOpenOnly
 		document.querySelector('#reset-filters')?.classList.toggle('hidden', isDefault)
 		updateMobileFilterBadge()
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<div class="max-w-5xl mx-auto px-6 py-8 flex gap-8 items-start">
+<div class="max-w-5xl mx-auto px-6 py-8 flex gap-5 items-start">
 
   {{ partial "home/sidebar.html" . }}
 

--- a/layouts/partials/home/sidebar.html
+++ b/layouts/partials/home/sidebar.html
@@ -35,7 +35,7 @@
 {{ end }}
 {{ $hqs = sort $hqs "sortKey" "asc" }}
 
-<aside class="hidden md:flex md:flex-col w-48 flex-shrink-0 pt-0.5 sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4">
+<aside class="hidden md:flex md:flex-col w-48 flex-shrink-0 pt-0.5 sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4 pr-2">
   {{/* Type filters as pill toggles */}}
   <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2">Filter</p>
   <div class="flex flex-col gap-0.5 mb-6">

--- a/layouts/partials/home/sidebar.html
+++ b/layouts/partials/home/sidebar.html
@@ -1,6 +1,6 @@
 {{/*
-  Homepage left sidebar: category filter + platform checkboxes.
-  Input: the /products section page context (has .Pages for platform counts).
+  Homepage left sidebar: type filter, platform checkboxes, HQ checkboxes.
+  Input: the /products section page context (has .Pages for counts).
 */}}
 
 {{/* Collect unique platforms with counts */}}
@@ -12,14 +12,28 @@
     {{ $platformMap = merge $platformMap (dict . $count) }}
   {{ end }}
 {{ end }}
-
-{{/* Build sortable slice: descending by count, then ascending by name */}}
 {{ $platforms := slice }}
 {{ range $name, $count := $platformMap }}
   {{ $sortKey := printf "%010d|%s" (math.Sub 9999999999 $count) $name }}
   {{ $platforms = $platforms | append (dict "name" $name "count" $count "sortKey" $sortKey) }}
 {{ end }}
 {{ $platforms = sort $platforms "sortKey" "asc" }}
+
+{{/* Collect unique HQs with counts */}}
+{{ $hqMap := dict }}
+{{ range .Pages }}
+  {{ range .Params.headquarters }}
+    {{ $count := 1 }}
+    {{ if isset $hqMap . }}{{ $count = add (index $hqMap .) 1 }}{{ end }}
+    {{ $hqMap = merge $hqMap (dict . $count) }}
+  {{ end }}
+{{ end }}
+{{ $hqs := slice }}
+{{ range $name, $count := $hqMap }}
+  {{ $sortKey := printf "%010d|%s" (math.Sub 9999999999 $count) $name }}
+  {{ $hqs = $hqs | append (dict "name" $name "count" $count "sortKey" $sortKey) }}
+{{ end }}
+{{ $hqs = sort $hqs "sortKey" "asc" }}
 
 <aside class="hidden md:block w-48 flex-shrink-0 pt-0.5 self-start sticky top-20">
   {{/* Type filters as pill toggles */}}
@@ -41,6 +55,18 @@
         <input type="checkbox" data-platform-checkbox="{{ .name }}" class="rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900/20 flex-shrink-0">
         <span class="flex-1 truncate">{{ .name }}</span>
         <span data-platform-count="{{ .name }}" class="text-neutral-400 text-xs tabular-nums">{{ .count }}</span>
+      </label>
+    {{ end }}
+  </div>
+
+  {{/* HQ / Country */}}
+  <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2 mt-6">Country</p>
+  <div class="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+    {{ range $hqs }}
+      <label class="flex items-center gap-2 px-3 py-1.5 text-sm text-neutral-600 cursor-pointer hover:bg-neutral-100 rounded-lg transition-colors">
+        <input type="checkbox" data-hq-checkbox="{{ .name | lower }}" class="rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900/20 flex-shrink-0">
+        <span class="flex-1 truncate">{{ .name }}</span>
+        <span data-hq-count="{{ .name | lower }}" class="text-neutral-400 text-xs tabular-nums">{{ .count }}</span>
       </label>
     {{ end }}
   </div>

--- a/layouts/partials/home/sidebar.html
+++ b/layouts/partials/home/sidebar.html
@@ -35,7 +35,7 @@
 {{ end }}
 {{ $hqs = sort $hqs "sortKey" "asc" }}
 
-<aside class="hidden md:block w-48 flex-shrink-0 pt-0.5 self-start sticky top-20">
+<aside class="hidden md:flex md:flex-col w-48 flex-shrink-0 pt-0.5 sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4">
   {{/* Type filters as pill toggles */}}
   <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2">Filter</p>
   <div class="flex flex-col gap-0.5 mb-6">
@@ -49,7 +49,7 @@
 
   {{/* Platform */}}
   <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2">Platform</p>
-  <div class="flex flex-col gap-0.5 max-h-64 overflow-y-auto">
+  <div class="flex flex-col gap-0.5">
     {{ range $platforms }}
       <label class="flex items-center gap-2 px-3 py-1.5 text-sm text-neutral-600 cursor-pointer hover:bg-neutral-100 rounded-lg transition-colors">
         <input type="checkbox" data-platform-checkbox="{{ .name }}" class="rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900/20 flex-shrink-0">
@@ -61,7 +61,7 @@
 
   {{/* HQ / Headquarters */}}
   <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2 mt-6">Headquarters</p>
-  <div class="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+  <div class="flex flex-col gap-0.5">
     {{ range $hqs }}
       <label class="flex items-center gap-2 px-3 py-1.5 text-sm text-neutral-600 cursor-pointer hover:bg-neutral-100 rounded-lg transition-colors">
         <input type="checkbox" data-hq-checkbox="{{ .name | lower }}" class="rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900/20 flex-shrink-0">

--- a/layouts/partials/home/sidebar.html
+++ b/layouts/partials/home/sidebar.html
@@ -59,8 +59,8 @@
     {{ end }}
   </div>
 
-  {{/* HQ / Country */}}
-  <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2 mt-6">Country</p>
+  {{/* HQ / Headquarters */}}
+  <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2 mt-6">Headquarters</p>
   <div class="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
     {{ range $hqs }}
       <label class="flex items-center gap-2 px-3 py-1.5 text-sm text-neutral-600 cursor-pointer hover:bg-neutral-100 rounded-lg transition-colors">

--- a/layouts/partials/home/sidebar.html
+++ b/layouts/partials/home/sidebar.html
@@ -35,7 +35,7 @@
 {{ end }}
 {{ $hqs = sort $hqs "sortKey" "asc" }}
 
-<aside class="hidden md:flex md:flex-col w-48 flex-shrink-0 pt-0.5 sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4 pr-2">
+<aside class="hidden md:flex md:flex-col w-56 flex-shrink-0 pt-0.5 sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4 pr-2">
   {{/* Type filters as pill toggles */}}
   <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 px-2">Filter</p>
   <div class="flex flex-col gap-0.5 mb-6">

--- a/layouts/partials/home/sort-bar.html
+++ b/layouts/partials/home/sort-bar.html
@@ -65,7 +65,7 @@
         </label>
         {{ end }}
       </div>
-      <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 mt-6">Country</p>
+      <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 mt-6">Headquarters</p>
       <div class="flex flex-col gap-0.5">
         {{ range $hqs }}
         <label class="flex items-center gap-2 px-3 py-2 text-sm text-neutral-600 cursor-pointer hover:bg-neutral-100 rounded-lg transition-colors">

--- a/layouts/partials/home/sort-bar.html
+++ b/layouts/partials/home/sort-bar.html
@@ -19,6 +19,22 @@
 {{ end }}
 {{ $platforms = sort $platforms "sortKey" "asc" }}
 
+{{/* Compute HQs sorted by count desc */}}
+{{ $hqMap := dict }}
+{{ range .Pages }}
+  {{ range .Params.headquarters }}
+    {{ $count := 1 }}
+    {{ if isset $hqMap . }}{{ $count = add (index $hqMap .) 1 }}{{ end }}
+    {{ $hqMap = merge $hqMap (dict . $count) }}
+  {{ end }}
+{{ end }}
+{{ $hqs := slice }}
+{{ range $name, $count := $hqMap }}
+  {{ $sortKey := printf "%010d|%s" (math.Sub 9999999999 $count) $name }}
+  {{ $hqs = $hqs | append (dict "name" $name "count" $count "sortKey" $sortKey) }}
+{{ end }}
+{{ $hqs = sort $hqs "sortKey" "asc" }}
+
 {{/* ── Mobile filter modal ──────────────────────────────────────── */}}
 <div id="mobile-filter-modal" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true">
   <div id="mobile-filter-backdrop" class="absolute inset-0 bg-black/40"></div>
@@ -44,6 +60,16 @@
         {{ range $platforms }}
         <label class="flex items-center gap-2 px-3 py-2 text-sm text-neutral-600 cursor-pointer hover:bg-neutral-100 rounded-lg transition-colors">
           <input type="checkbox" data-platform-checkbox="{{ .name }}" class="rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900/20 flex-shrink-0">
+          <span class="flex-1 truncate">{{ .name }}</span>
+          <span class="text-neutral-400 text-xs tabular-nums">{{ .count }}</span>
+        </label>
+        {{ end }}
+      </div>
+      <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-2 mt-6">Country</p>
+      <div class="flex flex-col gap-0.5">
+        {{ range $hqs }}
+        <label class="flex items-center gap-2 px-3 py-2 text-sm text-neutral-600 cursor-pointer hover:bg-neutral-100 rounded-lg transition-colors">
+          <input type="checkbox" data-hq-checkbox="{{ .name | lower }}" class="rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900/20 flex-shrink-0">
           <span class="flex-1 truncate">{{ .name }}</span>
           <span class="text-neutral-400 text-xs tabular-nums">{{ .count }}</span>
         </label>


### PR DESCRIPTION
## Summary

- New **Headquarters** filter section in the sidebar (desktop) and mobile filter modal, sorted by product count descending
- Selecting multiple countries uses OR logic — shows products headquartered in any of the selected countries
- Live counts update as other filters change
- Selected headquarters appear as removable pills on desktop and increment the mobile filter badge
- Sidebar is now scrollable as a whole (no nested scroll containers), with right padding so the scrollbar does not overlap text
- Sidebar widened slightly and gap between sidebar and product list reduced