### PR TITLE
data: update Uniguest founding year and add SSO/SAML support

### DIFF
--- a/data/products/uniguest.yaml
+++ b/data/products/uniguest.yaml
@@ -2,12 +2,14 @@ name: Uniguest
 slug: uniguest
 description: ""
 website: https://uniguest.com/
-year_founded: 2006
+year_founded: 1986
 headquarters:
   - USA
 open_source: false
 self_signup: false
 discontinued: false
+has_sso: true
+has_saml: true
 categories:
   - CMS
 platforms:


### PR DESCRIPTION
## Summary

- Corrects founding year from 2006 → 1986
- Adds `has_sso: true` and `has_saml: true` flags

Sources: https://uniguest.com/about-uniguest/ and https://uniguest.com/digital-signage/

Closes #103