### PR TITLE
data: update piSignage pricing, API, and SSO/SAML flags

### DIFF
--- a/data/products/pisignage.yaml
+++ b/data/products/pisignage.yaml
@@ -6,6 +6,10 @@ year_founded: 2014
 headquarters:
   - India
 open_source: false
+has_api: true
+developer_portal_url: https://piathome.com/apidocs/
+has_sso: true
+has_saml: true
 self_signup: true
 discontinued: false
 categories:
@@ -26,8 +30,8 @@ models:
       - name: Basic
         payment_model: subscription
         billing_basis: per_device
-        monthly: 3.43
-        yearly: null
+        monthly: 1.67
+        yearly: 1.67
 stats:
   screens:
     total: 125493


### PR DESCRIPTION
## Summary

- Corrects monthly price from \$3.43 → \$1.67/month (\$20/year billed annually)
- Adds `has_api: true` with developer portal URL (https://piathome.com/apidocs/)
- Adds `has_sso: true` and `has_saml: true`

Sources: https://pisignage.com/pricing, https://piathome.com/apidocs/, https://pisignage.com/signup/, https://www.pisignage.com/doc/signup-and-login

Closes #115
Closes #116
Closes #117