### PR TITLE
feat: add DisplayNXT

### DIFF
--- a/data/products/displaynxt.yaml
+++ b/data/products/displaynxt.yaml
@@ -3,7 +3,8 @@ slug: displaynxt
 description: Cloud-based digital signage platform for managing displays across any industry.
 website: https://displaynxt.pro
 year_founded: null
-headquarters: []
+headquarters:
+  - India
 open_source: false
 self_signup: true
 discontinued: false

--- a/data/products/displaynxt.yaml
+++ b/data/products/displaynxt.yaml
@@ -1,0 +1,28 @@
+name: DisplayNXT
+slug: displaynxt
+description: Cloud-based digital signage platform for managing displays across any industry.
+website: https://displaynxt.pro
+year_founded: null
+headquarters: []
+open_source: false
+self_signup: false
+discontinued: false
+categories:
+  - CMS
+platforms: []
+models:
+  - delivery: cloud
+    free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null

--- a/data/products/displaynxt.yaml
+++ b/data/products/displaynxt.yaml
@@ -5,17 +5,35 @@ website: https://displaynxt.pro
 year_founded: null
 headquarters: []
 open_source: false
-self_signup: false
+self_signup: true
 discontinued: false
 categories:
   - CMS
-platforms: []
+platforms:
+  - Android
+  - Tizen
+  - webOS
 models:
   - delivery: cloud
-    free_trial: false
-    pricing_available: false
+    free_trial: true
+    pricing_available: true
     has_freemium: false
-    pricing: []
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 19
+        yearly: null
+      - name: Business
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 49
+        yearly: null
+      - name: Enterprise
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 99
+        yearly: null
 stats: {}
 notes: []
 features: []


### PR DESCRIPTION
Adds DisplayNXT to the directory.

Minimal entry - the site is a JS SPA so platforms, pricing, and other details could not be scraped. Logo also unavailable (all asset paths redirect to the SPA). Fields to fill in later: headquarters, year founded, platforms, pricing, logo.

Closes #109