### PR TITLE
feat: add Gibeon

### DIFF
--- a/assets/logos/dark/gibeon.svg
+++ b/assets/logos/dark/gibeon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Gibeon comet"><g fill="#EC5B43"><circle cx="25" cy="40" r="18"/><path d="M23 24 C32 15 40 10 48 5 C47 12 46 17 45 22 C51 16 56 12 62 7 C56 20 48 30 40 36 C35 33 29 31 24 29 Z"/></g><circle cx="23" cy="43" r="12.5" fill="#F5C84B"/></svg>

--- a/data/products/gibeon.yaml
+++ b/data/products/gibeon.yaml
@@ -34,26 +34,35 @@ models:
         billing_basis: flat_rate
         monthly: 0
         yearly: 0
+        included_screens: 3
+        max_screens: 3
       - name: Starter
         payment_model: subscription
         billing_basis: flat_rate
         monthly: 39
         yearly: 390
+        included_screens: 5
+        max_screens: 5
       - name: Pro
         payment_model: subscription
         billing_basis: flat_rate
         monthly: null
         yearly: null
+        included_screens: 10
+        overage_per_screen: 5
       - name: Business
         payment_model: subscription
         billing_basis: flat_rate
         monthly: 198
         yearly: 1980
+        included_screens: 10
+        overage_per_screen: 5
       - name: Agency
         payment_model: subscription
         billing_basis: flat_rate
         monthly: 249
         yearly: 2490
+        included_screens: 20
       - name: Enterprise
         payment_model: subscription
         billing_basis: flat_rate

--- a/data/products/gibeon.yaml
+++ b/data/products/gibeon.yaml
@@ -1,0 +1,71 @@
+name: Gibeon
+slug: gibeon
+description: Cloud-based digital signage CMS built and hosted in the EU, with a freemium plan and broad platform support.
+website: https://www.gibeon.io
+year_founded: 2024
+headquarters:
+  - Belgium
+open_source: false
+has_api: true
+developer_portal_url: https://www.gibeon.io/dev
+has_mcp: true
+has_sso: true
+self_signup: true
+discontinued: false
+categories:
+  - CMS
+platforms:
+  - Android
+  - ChromeOS
+  - macOS
+  - Raspberry Pi
+  - Tizen
+  - Web Browser
+  - webOS
+  - Windows
+models:
+  - delivery: cloud
+    free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: free
+        billing_basis: flat_rate
+        monthly: 0
+        yearly: 0
+      - name: Starter
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 39
+        yearly: 390
+      - name: Pro
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: null
+        yearly: null
+      - name: Business
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 198
+        yearly: 1980
+      - name: Agency
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 249
+        yearly: 2490
+      - name: Enterprise
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: null
+        yearly: null
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null

--- a/scripts/lib/schema.ts
+++ b/scripts/lib/schema.ts
@@ -15,6 +15,9 @@ const PricingSchema = z.object({
 	monthly: z.number().nullable(),
 	yearly: z.number().nullable(),
 	price: z.number().nullable().optional(),
+	included_screens: z.number().int().nullable().default(null),
+	overage_per_screen: z.number().nullable().default(null),
+	max_screens: z.number().int().nullable().default(null),
 })
 
 const ModelSchema = z.object({


### PR DESCRIPTION
Adds Gibeon to the directory.

- Cloud, EU-hosted, freemium, self-signup
- Platforms: Android, ChromeOS, macOS, Raspberry Pi, Tizen, Web Browser, webOS, Windows
- 6 pricing tiers: Free, Starter (39/mo), Pro (price TBD), Business (198/mo), Agency (249/mo), Enterprise (custom)
- API, MCP, SSO (Google + Microsoft; SAML for Enterprise by contract)
- Logo from gibeon.io/brand/gibeon-comet.svg

Closes #113