### PR TITLE
data: add Bluefin platform and add to Carousel

### DIFF
--- a/content/platforms/bluefin/_index.md
+++ b/content/platforms/bluefin/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Bluefin"
+seo_title: "Bluefin Digital Signage Software"
+description: "Explore digital signage software compatible with Bluefin BrightSign built-in displays, commercial-grade screens with integrated media players for professional installations."
+---

--- a/data/products/carousel.yaml
+++ b/data/products/carousel.yaml
@@ -17,6 +17,7 @@ categories:
 platforms:
   - Amazon Signage
   - Android
+  - Bluefin
   - BrightSign
   - ChromeOS
   - iOS


### PR DESCRIPTION
Closes #107 (follow-up)

Adds Bluefin as a supported platform for Carousel. Bluefin displays are BrightSign built-in commercial screens -- added a new platform taxonomy page as well.