### PR TITLE
feat: redirect /products/ to home, make products stat non-clickable

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<div class="max-w-5xl mx-auto px-6 py-24 text-center">
+  <p class="text-sm font-medium text-neutral-400 uppercase tracking-widest mb-4">404</p>
+  <h1 class="text-3xl font-bold text-neutral-900 mb-3">Page not found</h1>
+  <p class="text-neutral-500 text-base mb-8 max-w-sm mx-auto">The page you're looking for doesn't exist or has been moved.</p>
+  <a href="/" class="inline-flex items-center gap-2 px-5 py-2.5 bg-neutral-900 text-white text-sm font-medium rounded-lg hover:bg-neutral-700 transition-colors">
+    &larr; Back to directory
+  </a>
+</div>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
     Browse and compare {{ len .Pages }}+ products across pricing, platform support, and licensing. Community-maintained, no vendor bias.
   </p>
   <div class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-neutral-600">
-    <a href="/products/" class="hover:text-neutral-900 transition-colors"><span class="font-semibold text-neutral-900">{{ len .Pages }}</span> products</a>
+    <span><span class="font-semibold text-neutral-900">{{ len .Pages }}</span> products</span>
     <a href="/categories/" class="hover:text-neutral-900 transition-colors"><span class="font-semibold text-neutral-900">{{ len site.Taxonomies.categories }}</span> categories</a>
     <a href="/platforms/" class="hover:text-neutral-900 transition-colors"><span class="font-semibold text-neutral-900">{{ len site.Taxonomies.platforms }}</span> platforms</a>
     <span class="text-neutral-600 text-xs sm:ml-2">Updated {{ now.Format "Jan 2, 2006" }}</span>

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -1,50 +1,10 @@
-{{ define "main" }}
-<div class="max-w-screen-xl w-full mx-auto px-4 py-6">
-	{{ partial "filters.html" . }}
-
-	<div class="table-wrapper rounded-lg border border-neutral-200 overflow-x-auto">
-		<table id="product-table" class="w-full">
-			<thead class="bg-neutral-50 border-b border-neutral-200">
-				<tr>
-					<th data-sort="name" class="py-3 px-4 text-left text-xs font-semibold text-neutral-500 uppercase tracking-wider" style="min-width:300px;max-width:500px">
-						Product<span class="sort-indicator ml-1"></span>
-					</th>
-					<th data-sort="pricing" class="py-3 px-4 text-left text-xs font-semibold text-neutral-500 uppercase tracking-wider" style="min-width:180px">
-						Pricing per screen<span class="sort-indicator ml-1"></span>
-					</th>
-					<th class="py-3 px-4 text-left text-xs font-semibold text-neutral-500 uppercase tracking-wider" style="min-width:120px">
-						Signup
-					</th>
-					<th class="py-3 px-4 text-left text-xs font-semibold text-neutral-500 uppercase tracking-wider" style="min-width:150px">
-						Headquarters
-					</th>
-					<th data-sort="screens" class="py-3 px-4 text-right text-xs font-semibold text-neutral-500 uppercase tracking-wider" style="min-width:120px">
-						Screens<span class="sort-indicator ml-1"></span>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				{{ range .Pages.ByTitle }}
-					{{ partial "product-row.html" . }}
-				{{ end }}
-			</tbody>
-		</table>
-	</div>
-
-	{{/* Empty state */}}
-	<div id="empty-state" class="hidden py-16 text-center">
-		<div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-neutral-100 mb-4">
-			<svg class="w-8 h-8 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
-		</div>
-		<h3 class="text-lg font-semibold text-neutral-900 mb-1">No products found</h3>
-		<p class="text-neutral-500 text-sm mb-4">Try adjusting your filters or search term</p>
-		<button id="empty-state-reset" class="px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors">Reset filters</button>
-	</div>
-
-	<div class="py-4 text-sm text-neutral-500">
-		Showing <span id="visible-count" class="tabular-nums font-medium text-neutral-700">{{ len .Pages }}</span> products
-	</div>
-</div>
-
-{{ partial "schema/item-list.html" . }}
-{{ end }}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/">
+<link rel="canonical" href="/">
+<script>window.location.replace("/");</script>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
- Replaces the /products/ list page with a redirect to / (homepage is now the product list)
- Makes the products count in the hero plain text instead of a link