### PR TITLE
feat: replace delivery string with deployments object

### DIFF
--- a/data/products/1glance.yaml
+++ b/data/products/1glance.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - tvOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/1play.yaml
+++ b/data/products/1play.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Raspberry Pi
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starter Price
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5.47
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starter Price
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5.47
+        yearly: null

--- a/data/products/22miles.yaml
+++ b/data/products/22miles.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 22000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/42-digital-signage.yaml
+++ b/data/products/42-digital-signage.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 12000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/4dcast.yaml
+++ b/data/products/4dcast.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/4yousee.yaml
+++ b/data/products/4yousee.yaml
@@ -16,17 +16,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Advanced
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 8.99
-        yearly: 85.9
 stats:
   screens:
     total: 40000
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Advanced
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 8.99
+        yearly: 85.9

--- a/data/products/ablesign.yaml
+++ b/data/products/ablesign.yaml
@@ -16,12 +16,6 @@ platforms:
   - Android
   - BrightSign
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/abuzz.yaml
+++ b/data/products/abuzz.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 470
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/acquire2go.yaml
+++ b/data/products/acquire2go.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 25000
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/acrelec.yaml
+++ b/data/products/acrelec.yaml
@@ -15,12 +15,6 @@ platforms:
   - Linux
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 80000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/acumen-cms.yaml
+++ b/data/products/acumen-cms.yaml
@@ -12,22 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Platinum
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 8
-        yearly: null
-      - name: Custom Advanced
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 11
-        yearly: null
 stats:
   screens:
     total: 30000
@@ -42,3 +26,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Platinum
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 8
+        yearly: null
+      - name: Custom Advanced
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 11
+        yearly: null

--- a/data/products/ad-sign.yaml
+++ b/data/products/ad-sign.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/adcast.yaml
+++ b/data/products/adcast.yaml
@@ -1,6 +1,8 @@
 name: AdCast
 slug: adcast
-description: Mobile-driven digital signage app for casting content to Android TV and Fire TV with playlist scheduling and remote updates.
+description: >-
+  Mobile-driven digital signage app for casting content to Android TV and Fire TV with playlist scheduling and remote
+  updates.
 website: https://adcast.app/
 year_founded: 2024
 headquarters:
@@ -13,17 +15,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: 1 Device
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 12.99
-        yearly: 129.99
 stats: {}
 notes: []
 features: []
@@ -34,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 1 Device
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 12.99
+        yearly: 129.99

--- a/data/products/addreality.yaml
+++ b/data/products/addreality.yaml
@@ -20,12 +20,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 60000
@@ -40,3 +34,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/adfloow.yaml
+++ b/data/products/adfloow.yaml
@@ -18,17 +18,6 @@ platforms:
   - Raspberry Pi
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: All features included
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 9.21
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -39,3 +28,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: All features included
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 9.21
+        yearly: null

--- a/data/products/admaster.yaml
+++ b/data/products/admaster.yaml
@@ -14,12 +14,6 @@ platforms:
   - Linux
   - Raspberry Pi
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/admefy.yaml
+++ b/data/products/admefy.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0

--- a/data/products/admira.yaml
+++ b/data/products/admira.yaml
@@ -20,17 +20,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Admira Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 17
-        yearly: null
 stats:
   screens:
     total: 40000
@@ -45,3 +34,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Admira Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 17
+        yearly: null

--- a/data/products/admooh.yaml
+++ b/data/products/admooh.yaml
@@ -18,17 +18,6 @@ platforms:
   - Raspberry Pi
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Light
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5.1
-        yearly: 51.95
 stats:
   screens:
     total: 20000
@@ -43,3 +32,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Light
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5.1
+        yearly: 51.95

--- a/data/products/adooh.yaml
+++ b/data/products/adooh.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/adscreen.yaml
+++ b/data/products/adscreen.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/adv-signage.yaml
+++ b/data/products/adv-signage.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/aem-screens.yaml
+++ b/data/products/aem-screens.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/agentview.yaml
+++ b/data/products/agentview.yaml
@@ -26,9 +26,22 @@ platforms:
   - Web Browser
   - webOS
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -42,13 +55,3 @@ models:
         billing_basis: per_device
         monthly: 4
         yearly: 40
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/airtame.yaml
+++ b/data/products/airtame.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Amazon Signage
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 10000
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/alpha-digital.yaml
+++ b/data/products/alpha-digital.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/alto.yaml
+++ b/data/products/alto.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/androidsignage.yaml
+++ b/data/products/androidsignage.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats:
   screens:
     total: 300
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/anthias.yaml
+++ b/data/products/anthias.yaml
@@ -15,12 +15,6 @@ categories:
 platforms:
   - Linux
   - Raspberry Pi
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/appspace.yaml
+++ b/data/products/appspace.yaml
@@ -22,12 +22,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -38,3 +32,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/appsuite.yaml
+++ b/data/products/appsuite.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing: []

--- a/data/products/arreya.yaml
+++ b/data/products/arreya.yaml
@@ -20,12 +20,6 @@ platforms:
   - Linux
   - Raspberry Pi
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/atmospheretv.yaml
+++ b/data/products/atmospheretv.yaml
@@ -18,12 +18,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 60000
@@ -38,3 +32,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/audience-cms.yaml
+++ b/data/products/audience-cms.yaml
@@ -17,12 +17,6 @@ platforms:
   - ChromeOS
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/autora-dsm.yaml
+++ b/data/products/autora-dsm.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/avesign.yaml
+++ b/data/products/avesign.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/avsign-lite.yaml
+++ b/data/products/avsign-lite.yaml
@@ -13,12 +13,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/aware.yaml
+++ b/data/products/aware.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/axistv.yaml
+++ b/data/products/axistv.yaml
@@ -1,6 +1,8 @@
 name: AxisTV
 slug: axistv
-description: Cloud-based digital signage software for creating content playlists across displays, webpages, desktops, and mobile devices.
+description: >-
+  Cloud-based digital signage software for creating content playlists across displays, webpages, desktops, and mobile
+  devices.
 website: https://www.visix.com/digital-signage-software/
 year_founded: 2000
 headquarters:
@@ -13,12 +15,6 @@ categories:
 platforms:
   - BrightSign
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 4000
@@ -33,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/beamer.yaml
+++ b/data/products/beamer.yaml
@@ -13,9 +13,22 @@ categories:
 platforms:
   - iOS
   - tvOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -29,13 +42,3 @@ models:
         billing_basis: flat_rate
         monthly: null
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/beeceen.yaml
+++ b/data/products/beeceen.yaml
@@ -17,17 +17,6 @@ platforms:
   - Linux
   - Windows
   - iOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Core
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 16
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Core
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 16
+        yearly: null

--- a/data/products/bharat-signage.yaml
+++ b/data/products/bharat-signage.yaml
@@ -13,22 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-      - name: Commercial
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5.91
-        yearly: 49.68
 stats:
   screens:
     total: 2100
@@ -43,3 +27,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Commercial
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5.91
+        yearly: 49.68

--- a/data/products/bizplay.yaml
+++ b/data/products/bizplay.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Raspberry Pi
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Smart
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 14.82
-        yearly: 151.68
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Smart
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 14.82
+        yearly: 151.68

--- a/data/products/blynk.yaml
+++ b/data/products/blynk.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 487
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/bohemica-signage.yaml
+++ b/data/products/bohemica-signage.yaml
@@ -14,9 +14,26 @@ platforms:
   - Linux
   - Raspberry Pi
   - Windows
+stats:
+  screens:
+    total: 2000
+    source: https://github.com/514sid/digital-signage-list/issues/42
+    date: 2025-07
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -40,17 +57,3 @@ models:
         billing_basis: per_device
         monthly: 7.99
         yearly: null
-stats:
-  screens:
-    total: 2000
-    source: https://github.com/514sid/digital-signage-list/issues/42
-    date: 2025-07
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/brandtv.yaml
+++ b/data/products/brandtv.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Cloud
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 17.18
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Cloud
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 17.18
+        yearly: null

--- a/data/products/brandvisionhd.yaml
+++ b/data/products/brandvisionhd.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - BrightSign
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/bravia-signage-free.yaml
+++ b/data/products/bravia-signage-free.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - BRAVIA
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0

--- a/data/products/breeze.yaml
+++ b/data/products/breeze.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing:
-      - name: Breeze TOTALCare
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: null
 stats:
   screens:
     total: 3000
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing:
+      - name: Breeze TOTALCare
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: null

--- a/data/products/bricks.yaml
+++ b/data/products/bricks.yaml
@@ -18,9 +18,22 @@ platforms:
   - Web Browser
   - iOS
   - macOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -34,13 +47,3 @@ models:
         billing_basis: per_device
         monthly: 5
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/brightsign.yaml
+++ b/data/products/brightsign.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - BrightSign
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: bsn.Control
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 139
 stats:
   screens:
     total: 2500000
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: bsn.Control
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 139

--- a/data/products/broadsign.yaml
+++ b/data/products/broadsign.yaml
@@ -15,12 +15,6 @@ platforms:
   - BrightSign
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 2000000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/budsense.yaml
+++ b/data/products/budsense.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/buetema.yaml
+++ b/data/products/buetema.yaml
@@ -14,17 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: DS frontend license
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 24
-        yearly: null
 stats:
   screens:
     total: 7500
@@ -39,3 +28,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: DS frontend license
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 24
+        yearly: null

--- a/data/products/butikstv.yaml
+++ b/data/products/butikstv.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starting price
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10.4
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starting price
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10.4
+        yearly: null

--- a/data/products/buzzblender.yaml
+++ b/data/products/buzzblender.yaml
@@ -18,9 +18,22 @@ platforms:
   - Web Browser
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -34,13 +47,3 @@ models:
         billing_basis: per_device
         monthly: 10
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/canvaspro.yaml
+++ b/data/products/canvaspro.yaml
@@ -10,12 +10,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -26,3 +20,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/carousel.yaml
+++ b/data/products/carousel.yaml
@@ -31,9 +31,22 @@ platforms:
   - webOS
   - Windows
   - Zoom Rooms
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: false
     pricing:
@@ -52,13 +65,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/casthub.yaml
+++ b/data/products/casthub.yaml
@@ -25,9 +25,22 @@ platforms:
   - Web Browser
   - webOS
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -46,13 +59,3 @@ models:
         billing_basis: flat_rate
         monthly: 95
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/castit.yaml
+++ b/data/products/castit.yaml
@@ -20,9 +20,22 @@ platforms:
   - Web Browser
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -36,13 +49,3 @@ models:
         billing_basis: per_device
         monthly: 21.66
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/castmill.yaml
+++ b/data/products/castmill.yaml
@@ -20,17 +20,6 @@ platforms:
   - Raspberry Pi
   - Web Browser
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starter
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 7.25
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starter
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 7.25
+        yearly: null

--- a/data/products/cayin.yaml
+++ b/data/products/cayin.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cenareo.yaml
+++ b/data/products/cenareo.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Tizen
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 25000
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/centoview.yaml
+++ b/data/products/centoview.yaml
@@ -14,12 +14,6 @@ platforms:
   - Linux
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 35000
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/chrome-sign-builder.yaml
+++ b/data/products/chrome-sign-builder.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - ChromeOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/cirrus-screenhub.yaml
+++ b/data/products/cirrus-screenhub.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/clarity.yaml
+++ b/data/products/clarity.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/clearconnect.yaml
+++ b/data/products/clearconnect.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cleverlive.yaml
+++ b/data/products/cleverlive.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 10000
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cleverq-picturemachine.yaml
+++ b/data/products/cleverq-picturemachine.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/clicandpublish.yaml
+++ b/data/products/clicandpublish.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cloudexa.yaml
+++ b/data/products/cloudexa.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 22400
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cloudshow.yaml
+++ b/data/products/cloudshow.yaml
@@ -16,9 +16,22 @@ platforms:
   - Fire OS
   - Windows
   - iOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -32,13 +45,3 @@ models:
         billing_basis: per_device
         monthly: 8
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/cloudyfy-tv.yaml
+++ b/data/products/cloudyfy-tv.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - iOS
   - tvOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 1000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cms-signage.yaml
+++ b/data/products/cms-signage.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Main
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: 110
 stats:
   screens:
     total: 700
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Main
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: 110

--- a/data/products/comeen.yaml
+++ b/data/products/comeen.yaml
@@ -20,17 +20,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starter
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 324
 stats: {}
 notes: []
 features: []
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starter
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 324

--- a/data/products/concerto.yaml
+++ b/data/products/concerto.yaml
@@ -17,12 +17,6 @@ platforms:
   - Fire OS
   - Raspberry Pi
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/connectedsign.yaml
+++ b/data/products/connectedsign.yaml
@@ -15,12 +15,6 @@ platforms:
   - BrightSign
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/control-play.yaml
+++ b/data/products/control-play.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/coolerx.yaml
+++ b/data/products/coolerx.yaml
@@ -14,12 +14,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/corevo.yaml
+++ b/data/products/corevo.yaml
@@ -17,12 +17,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 50000
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cortex.yaml
+++ b/data/products/cortex.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/crowntv.yaml
+++ b/data/products/crowntv.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 13500
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cs-play.yaml
+++ b/data/products/cs-play.yaml
@@ -18,12 +18,6 @@ platforms:
   - Raspberry Pi
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/cubic-media.yaml
+++ b/data/products/cubic-media.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 52000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/d-i-s-play.yaml
+++ b/data/products/d-i-s-play.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dakboard.yaml
+++ b/data/products/dakboard.yaml
@@ -4,39 +4,18 @@ description: WiFi-connected wall display for showing photos, calendars, news, an
 website: https://dakboard.com/site
 year_founded: 2015
 headquarters:
-    - USA
+  - USA
 open_source: false
 self_signup: true
 discontinued: false
 categories:
-    - CMS
+  - CMS
 platforms:
-    - Fire OS
-    - Raspberry Pi
-    - Web Browser
-    - Windows
-    - Android
-models:
-    - delivery: cloud
-      free_trial: true
-      pricing_available: true
-      has_freemium: true
-      pricing:
-        - name: Free (1 screen)
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 0
-          yearly: 0
-        - name: Essential (2 screens)
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 6
-          yearly: 60
-        - name: Plus (3 screens)
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 10
-          yearly: 96
+  - Fire OS
+  - Raspberry Pi
+  - Web Browser
+  - Windows
+  - Android
 stats: {}
 notes: []
 features: []
@@ -47,3 +26,27 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free (1 screen)
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Essential (2 screens)
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 6
+        yearly: 60
+      - name: Plus (3 screens)
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: 96

--- a/data/products/dcmcloud.yaml
+++ b/data/products/dcmcloud.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/deepiscreen.yaml
+++ b/data/products/deepiscreen.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 10000
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/denevads.yaml
+++ b/data/products/denevads.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 40000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/digichief-mercury.yaml
+++ b/data/products/digichief-mercury.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: ""
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 24
-        yearly: 21.6
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: ""
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 24
+        yearly: 21.6

--- a/data/products/digimago.yaml
+++ b/data/products/digimago.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/digiongo.yaml
+++ b/data/products/digiongo.yaml
@@ -1,43 +1,24 @@
 name: DigiOnGo
 slug: digiongo
 description: ""
-website: "https://digiongo.com/"
+website: https://digiongo.com/
 year_founded: 2025
-headquarters: ["Serbia"]
+headquarters:
+  - Serbia
 open_source: false
 rss_feed_url: null
 self_signup: false
 discontinued: false
-categories: ["CMS"]
+categories:
+  - CMS
 platforms:
-    - Android
-    - Fire OS
-models:
-    - delivery: cloud
-      free_trial: false
-      pricing_available: false
-      has_freemium: true
-      pricing:
-        - name: "1 screen"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 0
-          yearly: 0
-        - name: "Starter - From 5 screens"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 5.8
-          yearly: null
-        - name: "Professional - From 25 screens"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 3.16
-          yearly: null
+  - Android
+  - Fire OS
 stats:
-    screens:
-        total: 10
-        source: https://play.google.com/store/apps/details?id=io.digiongo.player
-        date: 2026-03
+  screens:
+    total: 10
+    source: https://play.google.com/store/apps/details?id=io.digiongo.player
+    date: 2026-03
 notes: []
 features: []
 integrations: []
@@ -47,3 +28,27 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing:
+      - name: 1 screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Starter - From 5 screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5.8
+        yearly: null
+      - name: Professional - From 25 screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 3.16
+        yearly: null

--- a/data/products/digisign-play.yaml
+++ b/data/products/digisign-play.yaml
@@ -17,17 +17,6 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Less than 80 screens
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 9
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Less than 80 screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 9
+        yearly: null

--- a/data/products/digisigns.yaml
+++ b/data/products/digisigns.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: STANDARD
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 20
-        yearly: 220
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: STANDARD
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 20
+        yearly: 220

--- a/data/products/digitalsignage-net.yaml
+++ b/data/products/digitalsignage-net.yaml
@@ -15,17 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starter
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 184
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starter
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 184

--- a/data/products/digitalsigns-ai.yaml
+++ b/data/products/digitalsigns-ai.yaml
@@ -1,6 +1,8 @@
 name: DigitalSigns.ai
 slug: digitalsigns-ai
-description: Cloud and on-premise digital signage CMS with a freemium plan and support for Android, ChromeOS, and web-based displays.
+description: >-
+  Cloud and on-premise digital signage CMS with a freemium plan and support for Android, ChromeOS, and web-based
+  displays.
 website: https://digitalsigns.ai
 year_founded: 2024
 headquarters:
@@ -16,22 +18,6 @@ platforms:
   - ChromeOS
   - Fire OS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: free
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-  - delivery: on-premise
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -42,3 +28,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: true
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: free
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0

--- a/data/products/digitalsigns.ai.yaml
+++ b/data/products/digitalsigns.ai.yaml
@@ -15,12 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/directable.yaml
+++ b/data/products/directable.yaml
@@ -14,17 +14,6 @@ platforms:
   - Amazon Signage
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: 2+ Screens
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 7.5
-        yearly: 67.5
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 2+ Screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 7.5
+        yearly: 67.5

--- a/data/products/dise.yaml
+++ b/data/products/dise.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 1000
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/disign.yaml
+++ b/data/products/disign.yaml
@@ -20,17 +20,6 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Media
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10.25
-        yearly: 109.32
 stats: {}
 notes: []
 features: []
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Media
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10.25
+        yearly: 109.32

--- a/data/products/displ.yaml
+++ b/data/products/displ.yaml
@@ -21,17 +21,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Screen Management
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 206
 stats:
   screens:
     total: 5000
@@ -47,3 +36,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Screen Management
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 206

--- a/data/products/displai.yaml
+++ b/data/products/displai.yaml
@@ -15,12 +15,6 @@ platforms:
   - ChromeOS
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Displai Systems Inc. has acquired the assets of Raydiant
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/display-now.yaml
+++ b/data/products/display-now.yaml
@@ -15,9 +15,22 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -31,13 +44,3 @@ models:
         billing_basis: per_device
         monthly: 11
         yearly: 108
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/display-star.yaml
+++ b/data/products/display-star.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/display-stream.yaml
+++ b/data/products/display-stream.yaml
@@ -18,9 +18,22 @@ platforms:
   - Raspberry Pi
   - Tizen
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -34,13 +47,3 @@ models:
         billing_basis: per_device
         monthly: 9
         yearly: 104
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/displayhub.yaml
+++ b/data/products/displayhub.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: LIGHT PACKAGE
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 21.58
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: LIGHT PACKAGE
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 21.58
+        yearly: null

--- a/data/products/displaymonkey.yaml
+++ b/data/products/displaymonkey.yaml
@@ -14,12 +14,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/displaynxt.yaml
+++ b/data/products/displaynxt.yaml
@@ -14,9 +14,22 @@ platforms:
   - Android
   - Tizen
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -35,13 +48,3 @@ models:
         billing_basis: flat_rate
         monthly: 99
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/displio.yaml
+++ b/data/products/displio.yaml
@@ -14,9 +14,22 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -35,13 +48,3 @@ models:
         billing_basis: per_device
         monthly: 18
         yearly: 178
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/disploy.yaml
+++ b/data/products/disploy.yaml
@@ -17,17 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: 96
 stats: {}
 notes: []
 features: []
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: 96

--- a/data/products/ditto.yaml
+++ b/data/products/ditto.yaml
@@ -18,9 +18,22 @@ platforms:
   - iOS
   - macOS
   - tvOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -39,13 +52,3 @@ models:
         billing_basis: per_device
         monthly: 29
         yearly: 175
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/donatello-suite.yaml
+++ b/data/products/donatello-suite.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/doohclick.yaml
+++ b/data/products/doohclick.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/doohlabs-in-store-impact.yaml
+++ b/data/products/doohlabs-in-store-impact.yaml
@@ -16,12 +16,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/doohly.yaml
+++ b/data/products/doohly.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/doohmain.yaml
+++ b/data/products/doohmain.yaml
@@ -18,12 +18,6 @@ platforms:
   - Raspberry Pi
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/door-tablet-signs.yaml
+++ b/data/products/door-tablet-signs.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dopublicity.yaml
+++ b/data/products/dopublicity.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dotsignage.yaml
+++ b/data/products/dotsignage.yaml
@@ -16,17 +16,6 @@ platforms:
   - Amazon Signage
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Standard
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 12
-        yearly: 120
 stats:
   screens:
     total: 7000
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 12
+        yearly: 120

--- a/data/products/download-player.yaml
+++ b/data/products/download-player.yaml
@@ -17,12 +17,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 103000
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dripboards.yaml
+++ b/data/products/dripboards.yaml
@@ -14,17 +14,6 @@ platforms:
   - Android
   - ChromeOS
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Monthly or Yearly
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 9.99
-        yearly: 99.99
 stats: {}
 notes:
   - You must have an active PosterMyWall subscription to use the Drip Boards Free Starter Subscription
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Monthly or Yearly
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 9.99
+        yearly: 99.99

--- a/data/products/ds-suit.yaml
+++ b/data/products/ds-suit.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 4500
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ds-templates.yaml
+++ b/data/products/ds-templates.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dsgo-pro.yaml
+++ b/data/products/dsgo-pro.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dsgo.yaml
+++ b/data/products/dsgo.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: ""
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 4.28
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: ""
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 4.28

--- a/data/products/dsplay.yaml
+++ b/data/products/dsplay.yaml
@@ -17,12 +17,6 @@ platforms:
   - Raspberry Pi
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dsshow.yaml
+++ b/data/products/dsshow.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/dst-connect.yaml
+++ b/data/products/dst-connect.yaml
@@ -12,17 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: ""
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 28.5
-        yearly: null
 stats:
   screens:
     total: 1000
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: ""
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 28.5
+        yearly: null

--- a/data/products/dvdify.yaml
+++ b/data/products/dvdify.yaml
@@ -1,38 +1,18 @@
-name: "Dvdify"
+name: Dvdify
 slug: dvdify
 description: ""
-website: "https://www.dvdify.com/"
+website: https://www.dvdify.com/
 year_founded: 2024
-headquarters: ["Canada"]
+headquarters:
+  - Canada
 open_source: false
 rss_feed_url: null
 self_signup: true
 discontinued: false
-categories: ["Content provider"]
-platforms: [
-  "Web Browser",
-]
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: "1 screen for 10 min"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 9.99
-        yearly: null
-      - name: "1 screen for 1 hour"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 19.99
-        yearly: null
-      - name: "1 screen for 10 hours"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 49.99
-        yearly: null
+categories:
+  - Content provider
+platforms:
+  - Web Browser
 stats: {}
 notes: []
 features: []
@@ -43,3 +23,27 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: 1 screen for 10 min
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 9.99
+        yearly: null
+      - name: 1 screen for 1 hour
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 19.99
+        yearly: null
+      - name: 1 screen for 10 hours
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 49.99
+        yearly: null

--- a/data/products/dydomite.yaml
+++ b/data/products/dydomite.yaml
@@ -15,9 +15,22 @@ platforms:
   - Linux
   - Windows
   - macOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -31,13 +44,3 @@ models:
         billing_basis: per_device
         monthly: 19
         yearly: 180
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/easescreen.yaml
+++ b/data/products/easescreen.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 10000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/easy-multi-display.yaml
+++ b/data/products/easy-multi-display.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/easy-signage.yaml
+++ b/data/products/easy-signage.yaml
@@ -19,9 +19,22 @@ platforms:
   - Tizen
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -35,13 +48,3 @@ models:
         billing_basis: per_device
         monthly: 9.98
         yearly: 99
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/easycms.yaml
+++ b/data/products/easycms.yaml
@@ -15,17 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: easyCMS Licence
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: null
 stats:
   screens:
     total: 322
@@ -40,3 +29,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: easyCMS Licence
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: null

--- a/data/products/easydisplay.yaml
+++ b/data/products/easydisplay.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/easyscreen.yaml
+++ b/data/products/easyscreen.yaml
@@ -15,17 +15,6 @@ platforms:
   - Tizen
   - Web Browser
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: 1 year
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 413
 stats:
   screens:
     total: 10000
@@ -40,3 +29,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 1 year
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 413

--- a/data/products/eggs-tv.yaml
+++ b/data/products/eggs-tv.yaml
@@ -12,15 +12,11 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
-  - There is no pricing per screen, only per location, so we are not mentioning plans because it can be extremely expensive or ultra cheap depending on the number of screens in a location.
+  - >-
+    There is no pricing per screen, only per location, so we are not mentioning plans because it can be extremely
+    expensive or ultra cheap depending on the number of screens in a location.
 features: []
 integrations: []
 target_audience: []
@@ -29,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/emagentv.yaml
+++ b/data/products/emagentv.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 15000
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/embed-signage.yaml
+++ b/data/products/embed-signage.yaml
@@ -22,17 +22,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: embed annual
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 185
 stats: {}
 notes: []
 features: []
@@ -43,3 +32,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: embed annual
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 185

--- a/data/products/emity.yaml
+++ b/data/products/emity.yaml
@@ -21,12 +21,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 5000
@@ -41,3 +35,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/engage.yaml
+++ b/data/products/engage.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - BrightSign
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/engageiot.yaml
+++ b/data/products/engageiot.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Software for kiosk management
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/engagesuite.yaml
+++ b/data/products/engagesuite.yaml
@@ -15,16 +15,11 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 120000
-    source: https://www.linkedin.com/company/zetadisplay/?utm_campaign=Global-%20Newsletter&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_p7VztyRT_Em6v_YcQLol_-IgMZ_dy29VxPAbqplr6ySGfv3x7M5eyr1tCN5viNmfBD9qW
+    source: >-
+      https://www.linkedin.com/company/zetadisplay/?utm_campaign=Global-%20Newsletter&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_p7VztyRT_Em6v_YcQLol_-IgMZ_dy29VxPAbqplr6ySGfv3x7M5eyr1tCN5viNmfBD9qW
     date: 2025-04
 notes: []
 features: []
@@ -35,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/enplug.yaml
+++ b/data/products/enplug.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Growth
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 32
-        yearly: null
 stats: {}
 notes:
   - Spectrio acquired Enplug in 2021.
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Growth
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 32
+        yearly: null

--- a/data/products/eumedia-dss.yaml
+++ b/data/products/eumedia-dss.yaml
@@ -15,12 +15,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/evergreen.yaml
+++ b/data/products/evergreen.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/exclaim.yaml
+++ b/data/products/exclaim.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: 3 Screens
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 3 Screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5
+        yearly: null

--- a/data/products/explorestream.yaml
+++ b/data/products/explorestream.yaml
@@ -1,21 +1,18 @@
-name: "Stream"
+name: Stream
 slug: explorestream
 description: ""
 website: https://explorestream.com/
 year_founded: 2017
-headquarters: ["USA", "Canada"]
+headquarters:
+  - USA
+  - Canada
 open_source: false
 rss_feed_url: null
 self_signup: false
 discontinued: false
-categories: ["CMS"]
+categories:
+  - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -26,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/eye-intelligence.yaml
+++ b/data/products/eye-intelligence.yaml
@@ -17,12 +17,6 @@ platforms:
   - Linux
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/eyecon.yaml
+++ b/data/products/eyecon.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ez-ad-tv.yaml
+++ b/data/products/ez-ad-tv.yaml
@@ -11,22 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-      - name: Silver
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 15
-        yearly: null
 stats:
   screens:
     total: 30000
@@ -41,3 +25,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Silver
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 15
+        yearly: null

--- a/data/products/eze-suite.yaml
+++ b/data/products/eze-suite.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 50000
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ezposter.yaml
+++ b/data/products/ezposter.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/eztv.yaml
+++ b/data/products/eztv.yaml
@@ -13,9 +13,22 @@ categories:
   - CMS
 platforms:
   - tvOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -29,13 +42,3 @@ models:
         billing_basis: per_device
         monthly: 2.99
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/fastpano.yaml
+++ b/data/products/fastpano.yaml
@@ -1,30 +1,20 @@
-name: "fastPano"
+name: fastPano
 slug: fastpano
 description: ""
-website: "https://fastpano.com/"
+website: https://fastpano.com/
 year_founded: 2026
-headquarters: ["Turkey"]
+headquarters:
+  - Turkey
 open_source: false
 rss_feed_url: null
 self_signup: true
 discontinued: false
 has_logo: true
-categories: ["CMS"]
+categories:
+  - CMS
 platforms:
-    - Android
-    - Fire OS
-models:
-    - delivery: self-hosted
-      free_trial: false
-      pricing_available: true
-      has_freemium: false
-      pricing:
-        - name: ""
-          payment_model: one-time
-          billing_basis: per_device
-          monthly: null
-          yearly: null
-          price: 8.8
+  - Android
+  - Fire OS
 stats: {}
 notes: []
 features: []
@@ -35,3 +25,18 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: null
+  on_premise: null
+  self_hosted: true
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: ""
+        payment_model: one-time
+        billing_basis: per_device
+        monthly: null
+        yearly: null
+        price: 8.8

--- a/data/products/feedsome.yaml
+++ b/data/products/feedsome.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/fijee.yaml
+++ b/data/products/fijee.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Cloud
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 4.7
-        yearly: 47
 stats: {}
 notes:
   - Formerly known as Phygital Signage (phygitalsignage.io)
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Cloud
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 4.7
+        yearly: 47

--- a/data/products/fingermark-supernova.yaml
+++ b/data/products/fingermark-supernova.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/firmchannel.yaml
+++ b/data/products/firmchannel.yaml
@@ -20,17 +20,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Standard
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 19.95
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 19.95
+        yearly: null

--- a/data/products/firstouch.yaml
+++ b/data/products/firstouch.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 30000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/five-faces.yaml
+++ b/data/products/five-faces.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/flagship-cms.yaml
+++ b/data/products/flagship-cms.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/flexitive.yaml
+++ b/data/products/flexitive.yaml
@@ -11,9 +11,22 @@ discontinued: false
 categories:
   - Content provider
 platforms: []
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -27,13 +40,3 @@ models:
         billing_basis: per_user
         monthly: null
         yearly: 1068
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/foyer.yaml
+++ b/data/products/foyer.yaml
@@ -14,12 +14,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes:
   - Digital Signage for WordPress.
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/framen.yaml
+++ b/data/products/framen.yaml
@@ -14,22 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-      - name: Premium
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 136.8
 stats:
   screens:
     total: 18000
@@ -44,3 +28,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Premium
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 136.8

--- a/data/products/framr.yaml
+++ b/data/products/framr.yaml
@@ -15,17 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: FRAMR.Propeller
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 94.56
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: FRAMR.Propeller
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 94.56

--- a/data/products/friendlyway.yaml
+++ b/data/products/friendlyway.yaml
@@ -15,12 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 25000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/frontface.yaml
+++ b/data/products/frontface.yaml
@@ -14,17 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Flexible Subscription License for one Player
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 39.95
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Flexible Subscription License for one Player
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 39.95
+        yearly: null

--- a/data/products/fugo.yaml
+++ b/data/products/fugo.yaml
@@ -21,9 +21,22 @@ platforms:
   - Raspberry Pi
   - Web Browser
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -42,13 +55,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 400
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/funeralscreen.yaml
+++ b/data/products/funeralscreen.yaml
@@ -18,9 +18,22 @@ platforms:
   - Tizen
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -39,13 +52,3 @@ models:
         billing_basis: per_device
         monthly: 38
         yearly: 420
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/fusion-signage.yaml
+++ b/data/products/fusion-signage.yaml
@@ -24,27 +24,6 @@ platforms:
   - Web Browser
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 124
-      - name: Advanced
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 170
-      - name: Pro
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 261
 stats:
   screens:
     total: 19500
@@ -65,3 +44,27 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 124
+      - name: Advanced
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 170
+      - name: Pro
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 261

--- a/data/products/fyresign.yaml
+++ b/data/products/fyresign.yaml
@@ -19,9 +19,23 @@ platforms:
   - Web Browser
   - Windows
   - iOS
+stats: {}
+notes:
+  - Formerly known as SocialScreen
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -35,14 +49,3 @@ models:
         billing_basis: per_device
         monthly: 13.9
         yearly: null
-stats: {}
-notes:
-  - Formerly known as SocialScreen
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/garlic-signage.yaml
+++ b/data/products/garlic-signage.yaml
@@ -19,12 +19,6 @@ platforms:
   - Web Browser
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - You can buy professional support via SmilControl
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/gibeon.yaml
+++ b/data/products/gibeon.yaml
@@ -23,9 +23,22 @@ platforms:
   - Web Browser
   - webOS
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -68,13 +81,3 @@ models:
         billing_basis: flat_rate
         monthly: null
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/glootv.yaml
+++ b/data/products/glootv.yaml
@@ -15,17 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Simple pricing
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 15
-        yearly: 132
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Simple pricing
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 15
+        yearly: 132

--- a/data/products/gobright.yaml
+++ b/data/products/gobright.yaml
@@ -15,12 +15,6 @@ platforms:
   - Android
   - Fire OS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/gotiger.yaml
+++ b/data/products/gotiger.yaml
@@ -14,12 +14,6 @@ platforms:
   - Linux
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/grassfish-ixm-platform.yaml
+++ b/data/products/grassfish-ixm-platform.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Windows
   - iOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/greenscreens.yaml
+++ b/data/products/greenscreens.yaml
@@ -1,6 +1,8 @@
 name: GreenScreens
 slug: greenscreens
-description: Digital signage and SaaS platform for cannabis dispensaries with real-time menu updates and product information displays.
+description: >-
+  Digital signage and SaaS platform for cannabis dispensaries with real-time menu updates and product information
+  displays.
 website: https://greenscreens.tv/
 year_founded: 2017
 headquarters:
@@ -11,17 +13,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Dispensary Starter
-        payment_model: subscription
-        billing_basis: per_location
-        monthly: 150
-        yearly: 1425
 stats: {}
 notes: []
 features: []
@@ -32,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Dispensary Starter
+        payment_model: subscription
+        billing_basis: per_location
+        monthly: 150
+        yearly: 1425

--- a/data/products/greet-tv.yaml
+++ b/data/products/greet-tv.yaml
@@ -16,9 +16,22 @@ platforms:
   - Windows
   - iOS
   - macOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -32,13 +45,3 @@ models:
         billing_basis: per_device
         monthly: 17
         yearly: 190
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/grubbrr.yaml
+++ b/data/products/grubbrr.yaml
@@ -17,12 +17,6 @@ platforms:
   - Fire OS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/haivision-coolsign.yaml
+++ b/data/products/haivision-coolsign.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/halo.yaml
+++ b/data/products/halo.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Standard 12 month contract
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 302.99
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Standard 12 month contract
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 302.99

--- a/data/products/harmony-digital.yaml
+++ b/data/products/harmony-digital.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Per screen
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 16
-        yearly: 160
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Per screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 16
+        yearly: 160

--- a/data/products/helloscreens.yaml
+++ b/data/products/helloscreens.yaml
@@ -12,9 +12,26 @@ categories:
   - CMS
 platforms:
   - Windows
+stats:
+  screens:
+    total: 15000
+    source: https://helloscreens.io/contact/
+    date: 2025-04
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -33,17 +50,3 @@ models:
         billing_basis: per_device
         monthly: 12.99
         yearly: null
-stats:
-  screens:
-    total: 15000
-    source: https://helloscreens.io/contact/
-    date: 2025-04
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/hexa.yaml
+++ b/data/products/hexa.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/hexnode.yaml
+++ b/data/products/hexnode.yaml
@@ -20,9 +20,22 @@ platforms:
   - iOS
   - macOS
   - tvOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -41,13 +54,3 @@ models:
         billing_basis: per_device
         monthly: 5.2
         yearly: 56.4
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/hfl-signage-player.yaml
+++ b/data/products/hfl-signage-player.yaml
@@ -14,12 +14,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/highview.yaml
+++ b/data/products/highview.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 45000
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/hipdeck.yaml
+++ b/data/products/hipdeck.yaml
@@ -14,9 +14,22 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -30,13 +43,3 @@ models:
         billing_basis: per_device
         monthly: 5
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/hydro-cms.yaml
+++ b/data/products/hydro-cms.yaml
@@ -20,12 +20,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/hyper-net.yaml
+++ b/data/products/hyper-net.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 2000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/hypersign.yaml
+++ b/data/products/hypersign.yaml
@@ -19,9 +19,22 @@ platforms:
   - Windows
   - iOS
   - macOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -40,13 +53,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 648.96
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/icompel.yaml
+++ b/data/products/icompel.yaml
@@ -16,12 +16,6 @@ platforms:
   - Tizen
   - Web Browser
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/idesk.yaml
+++ b/data/products/idesk.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/idid.yaml
+++ b/data/products/idid.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/idplay.yaml
+++ b/data/products/idplay.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ievince.yaml
+++ b/data/products/ievince.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/iisignage.yaml
+++ b/data/products/iisignage.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - iiyama
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
 stats: {}
 notes:
   - To work with iiSignage the PC or notebook needs to be connected to the same (LAN/WiFi) network as the displays.
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0

--- a/data/products/iisignage2.yaml
+++ b/data/products/iisignage2.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - iiyama
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ijjix.yaml
+++ b/data/products/ijjix.yaml
@@ -1,38 +1,19 @@
-name: "ijjix"
+name: ijjix
 slug: ijjix
 description: ""
-website: "https://ijjix.xyz/en"
+website: https://ijjix.xyz/en
 year_founded: 2025
-headquarters: ["Brazil"]
+headquarters:
+  - Brazil
 open_source: false
 rss_feed_url: null
 self_signup: true
 discontinued: false
-categories: ["CMS"]
+categories:
+  - CMS
 platforms:
-    - "Android"
-    - Fire OS
-models:
-    - delivery: cloud
-      free_trial: false
-      pricing_available: true
-      has_freemium: false
-      pricing:
-        - name: "Start - 1 to 20 screens"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 4
-          yearly: 35
-        - name: "Pro - 20 to 500 screens"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 3
-          yearly: 30
-        - name: "Enterprise - 500+ screens"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 2.5
-          yearly: 25
+  - Android
+  - Fire OS
 stats: {}
 notes: []
 features: []
@@ -43,3 +24,27 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Start - 1 to 20 screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 4
+        yearly: 35
+      - name: Pro - 20 to 500 screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 3
+        yearly: 30
+      - name: Enterprise - 500+ screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 2.5
+        yearly: 25

--- a/data/products/imidiatv.yaml
+++ b/data/products/imidiatv.yaml
@@ -17,12 +17,6 @@ platforms:
   - Linux
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 12000
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/immerse.yaml
+++ b/data/products/immerse.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/impressbox.yaml
+++ b/data/products/impressbox.yaml
@@ -18,17 +18,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Player
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 21.66
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -39,3 +28,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Player
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 21.66
+        yearly: null

--- a/data/products/infini-sign.yaml
+++ b/data/products/infini-sign.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/infinite-digital-cms.yaml
+++ b/data/products/infinite-digital-cms.yaml
@@ -21,12 +21,6 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/infinitys-anima.yaml
+++ b/data/products/infinitys-anima.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 1000
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/info-beamer-oss.yaml
+++ b/data/products/info-beamer-oss.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Linux
   - Raspberry Pi
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/info-beamer.yaml
+++ b/data/products/info-beamer.yaml
@@ -14,9 +14,22 @@ categories:
 platforms:
   - Linux
   - Raspberry Pi
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -30,13 +43,3 @@ models:
         billing_basis: per_device
         monthly: 8.84
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/infobox.yaml
+++ b/data/products/infobox.yaml
@@ -19,17 +19,6 @@ platforms:
   - Tizen
   - Web Browser
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: InfoBox Platform
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 7
-        yearly: 84
 stats: {}
 notes: []
 features: []
@@ -40,3 +29,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: InfoBox Platform
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 7
+        yearly: 84

--- a/data/products/innes.yaml
+++ b/data/products/innes.yaml
@@ -11,12 +11,6 @@ discontinued: true
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Had 40,000 screens in 2024
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/innovative-dmc.yaml
+++ b/data/products/innovative-dmc.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 10000
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/intelisa.yaml
+++ b/data/products/intelisa.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/interads.yaml
+++ b/data/products/interads.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/intraactive-replay.yaml
+++ b/data/products/intraactive-replay.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 14.85
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 14.85
+        yearly: null

--- a/data/products/intuiface.yaml
+++ b/data/products/intuiface.yaml
@@ -23,17 +23,6 @@ platforms:
   - Tizen
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Non-Interactive Player
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 36.18
-        yearly: 173.66
 stats: {}
 notes: []
 features: []
@@ -44,3 +33,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Non-Interactive Player
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 36.18
+        yearly: 173.66

--- a/data/products/ipoint.yaml
+++ b/data/products/ipoint.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Player per screen
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 199
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Player per screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 199

--- a/data/products/is-media.yaml
+++ b/data/products/is-media.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/iteq.yaml
+++ b/data/products/iteq.yaml
@@ -14,9 +14,27 @@ categories:
 platforms:
   - Android
   - Fire OS
+stats:
+  screens:
+    total: 81600
+    source: https://iteq.rs/en/
+    date: 2025-04
+notes:
+  - The total number of screens is based on the number daily broadcast spots
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: false
     pricing:
@@ -35,18 +53,3 @@ models:
         billing_basis: per_device
         monthly: 13
         yearly: null
-stats:
-  screens:
-    total: 81600
-    source: https://iteq.rs/en/
-    date: 2025-04
-notes:
-  - The total number of screens is based on the number daily broadcast spots
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/itotem.yaml
+++ b/data/products/itotem.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/jiosignage.yaml
+++ b/data/products/jiosignage.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Advanced Users
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 25
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Advanced Users
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 25
+        yearly: null

--- a/data/products/jiothings-jiosignage.yaml
+++ b/data/products/jiothings-jiosignage.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/joan.yaml
+++ b/data/products/joan.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Crestron AirMedia
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Essentials
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 205.2
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Essentials
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 205.2

--- a/data/products/juuno.yaml
+++ b/data/products/juuno.yaml
@@ -17,17 +17,6 @@ platforms:
   - Fire OS
   - Raspberry Pi
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Pay by the screen
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Pay by the screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5
+        yearly: null

--- a/data/products/kiocast.yaml
+++ b/data/products/kiocast.yaml
@@ -12,9 +12,22 @@ categories:
   - CMS
 platforms:
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: true
+  self_hosted: null
 models:
-  - delivery: hybrid
-    free_trial: false
+  - free_trial: false
     pricing_available: false
     has_freemium: false
     pricing:
@@ -28,13 +41,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/kitcast.yaml
+++ b/data/products/kitcast.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - tvOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Growth
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 25
-        yearly: 240
 stats: {}
 notes:
   - "Digital Signage Software for Apple TV. Platforms planned for 2025: Android, Fire OS, BrightSign, Tizen, webOS, macOS"
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Growth
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 25
+        yearly: 240

--- a/data/products/kiwi-signage.yaml
+++ b/data/products/kiwi-signage.yaml
@@ -17,17 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: PREMIUM
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 16.99
-        yearly: 136.73
 stats: {}
 notes: []
 features: []
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: PREMIUM
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 16.99
+        yearly: 136.73

--- a/data/products/koesio-tv.yaml
+++ b/data/products/koesio-tv.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/koke.yaml
+++ b/data/products/koke.yaml
@@ -16,17 +16,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Device License
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 16.63
-        yearly: null
 stats:
   screens:
     total: 3523
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Device License
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 16.63
+        yearly: null

--- a/data/products/korbyt.yaml
+++ b/data/products/korbyt.yaml
@@ -22,12 +22,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -38,3 +32,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/l-squared.yaml
+++ b/data/products/l-squared.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Raspberry Pi
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Professional
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 365
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Professional
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 365

--- a/data/products/laqorr.yaml
+++ b/data/products/laqorr.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ldsk.yaml
+++ b/data/products/ldsk.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/led-display-cms.yaml
+++ b/data/products/led-display-cms.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ledsee.yaml
+++ b/data/products/ledsee.yaml
@@ -20,12 +20,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/leftclick.yaml
+++ b/data/products/leftclick.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/lg-supersign.yaml
+++ b/data/products/lg-supersign.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/libre-signage.yaml
+++ b/data/products/libre-signage.yaml
@@ -14,12 +14,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/lifeloop.yaml
+++ b/data/products/lifeloop.yaml
@@ -4,22 +4,16 @@ description: ""
 website: https://lifeloop.com/our-solution
 year_founded: 2025
 headquarters:
-    - USA
+  - USA
 open_source: false
 self_signup: false
 discontinued: false
 categories:
-    - CMS
+  - CMS
 platforms:
-    - Amazon Signage
-    - Fire OS
-    - Android
-models:
-    - delivery: cloud
-      free_trial: false
-      pricing_available: false
-      has_freemium: false
-      pricing: []
+  - Amazon Signage
+  - Fire OS
+  - Android
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/liqvid.yaml
+++ b/data/products/liqvid.yaml
@@ -15,22 +15,6 @@ platforms:
   - Amazon Signage
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-      - name: Premium
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 9.9
-        yearly: 79.2
 stats:
   screens:
     total: 7000
@@ -46,3 +30,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Premium
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 9.9
+        yearly: 79.2

--- a/data/products/lira-screen.yaml
+++ b/data/products/lira-screen.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Standard
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 12
-        yearly: 120
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 12
+        yearly: 120

--- a/data/products/livesignage.yaml
+++ b/data/products/livesignage.yaml
@@ -18,17 +18,6 @@ platforms:
   - Linux
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 22
-        yearly: null
 stats:
   screens:
     total: 1100
@@ -43,3 +32,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 22
+        yearly: null

--- a/data/products/livespace.yaml
+++ b/data/products/livespace.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/localscreens.yaml
+++ b/data/products/localscreens.yaml
@@ -13,9 +13,23 @@ categories:
   - CMS
 platforms:
   - Windows
+stats: {}
+notes:
+  - Helloscreens whitelabel solution.
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: false
     pricing:
@@ -34,14 +48,3 @@ models:
         billing_basis: per_device
         monthly: 15
         yearly: null
-stats: {}
-notes:
-  - Helloscreens whitelabel solution.
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/look-ds.yaml
+++ b/data/products/look-ds.yaml
@@ -22,17 +22,6 @@ platforms:
   - Windows
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: 1-5 Screens
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 15
-        yearly: 162
 stats:
   screens:
     total: 25000
@@ -47,3 +36,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 1-5 Screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 15
+        yearly: 162

--- a/data/products/lookr.yaml
+++ b/data/products/lookr.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/loop-tv.yaml
+++ b/data/products/loop-tv.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 22000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/loopsign.yaml
+++ b/data/products/loopsign.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/lumicast.yaml
+++ b/data/products/lumicast.yaml
@@ -20,17 +20,6 @@ platforms:
   - Windows
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Solo
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 19.38
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Solo
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 19.38
+        yearly: null

--- a/data/products/lumoplay.yaml
+++ b/data/products/lumoplay.yaml
@@ -1,6 +1,8 @@
 name: LUMOplay
 slug: lumoplay
-description: Interactive projection software that turns projectors or screens into interactive floors and walls with 350+ built-in apps.
+description: >-
+  Interactive projection software that turns projectors or screens into interactive floors and walls with 350+ built-in
+  apps.
 website: https://www.lumoplay.com/
 year_founded: 2013
 headquarters:
@@ -11,9 +13,22 @@ discontinued: false
 categories:
   - CMS
 platforms: []
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -27,13 +42,3 @@ models:
         billing_basis: per_device
         monthly: 73.86
         yearly: 585.12
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/luna-screens.yaml
+++ b/data/products/luna-screens.yaml
@@ -13,9 +13,27 @@ categories:
 platforms:
   - Android
   - Fire OS
+stats:
+  screens:
+    total: 1000
+    source: >-
+      https://www.sixteen-nine.net/2025/03/17/alastair-taft-of-tasmanias-luna-screens-explains-his-approach-to-really-simple-digital-signage-software/
+    date: 2025-03
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -29,17 +47,3 @@ models:
         billing_basis: per_device
         monthly: 3.75
         yearly: 35
-stats:
-  screens:
-    total: 1000
-    source: https://www.sixteen-nine.net/2025/03/17/alastair-taft-of-tasmanias-luna-screens-explains-his-approach-to-really-simple-digital-signage-software/
-    date: 2025-03
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/m-cube.yaml
+++ b/data/products/m-cube.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 65000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/m4b-wall.yaml
+++ b/data/products/m4b-wall.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 30000
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/magic-mirror.yaml
+++ b/data/products/magic-mirror.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Software only comes in a package with a hardware as well.
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/magicinfo.yaml
+++ b/data/products/magicinfo.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Tizen
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/magicsign.yaml
+++ b/data/products/magicsign.yaml
@@ -17,12 +17,6 @@ platforms:
   - Web Browser
   - Windows
   - iOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/magit-dsnet.yaml
+++ b/data/products/magit-dsnet.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mandoe.yaml
+++ b/data/products/mandoe.yaml
@@ -16,17 +16,6 @@ platforms:
   - Linux
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 14
-        yearly: null
 stats:
   screens:
     total: 25000
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 14
+        yearly: null

--- a/data/products/mango-display.yaml
+++ b/data/products/mango-display.yaml
@@ -19,22 +19,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: FREE
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-      - name: PLUS
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 2.99
-        yearly: 29.99
 stats:
   screens:
     total: 10000
@@ -50,3 +34,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: FREE
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: PLUS
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 2.99
+        yearly: 29.99

--- a/data/products/mangosigns.yaml
+++ b/data/products/mangosigns.yaml
@@ -16,9 +16,23 @@ platforms:
   - ChromeOS
   - Fire OS
   - Windows
+stats: {}
+notes:
+  - 20% discounts for non-profit organizations, educational institutions or places of worship.
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -37,14 +51,3 @@ models:
         billing_basis: per_device
         monthly: 24.95
         yearly: 269.4
-stats: {}
-notes:
-  - 20% discounts for non-profit organizations, educational institutions or places of worship.
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/marve-ds.yaml
+++ b/data/products/marve-ds.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/master-signage.yaml
+++ b/data/products/master-signage.yaml
@@ -14,12 +14,6 @@ platforms:
   - Linux
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mcoms.yaml
+++ b/data/products/mcoms.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/media4display.yaml
+++ b/data/products/media4display.yaml
@@ -15,12 +15,6 @@ platforms:
   - Crestron AirMedia
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 500000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mediacast.yaml
+++ b/data/products/mediacast.yaml
@@ -16,12 +16,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mediacloud.yaml
+++ b/data/products/mediacloud.yaml
@@ -11,9 +11,22 @@ discontinued: false
 categories:
   - CMS
 platforms: []
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -27,13 +40,3 @@ models:
         billing_basis: per_device
         monthly: 3
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/mediafusion.yaml
+++ b/data/products/mediafusion.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mediamanager.yaml
+++ b/data/products/mediamanager.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 12500
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mediasignage.yaml
+++ b/data/products/mediasignage.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Linux
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mediatile.yaml
+++ b/data/products/mediatile.yaml
@@ -18,17 +18,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Standard
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 239
 stats: {}
 notes: []
 features: []
@@ -39,3 +28,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 239

--- a/data/products/mediax.yaml
+++ b/data/products/mediax.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Starter
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 2.5
-        yearly: 25
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Starter
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 2.5
+        yearly: 25

--- a/data/products/medisign.yaml
+++ b/data/products/medisign.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Healthcare platform offering digital patient whiteboards & door displays.
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/medyapin.yaml
+++ b/data/products/medyapin.yaml
@@ -17,17 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Per screen
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 27
-        yearly: 270
 stats:
   screens:
     total: 7000
@@ -42,3 +31,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Per screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 27
+        yearly: 270

--- a/data/products/menara-ds.yaml
+++ b/data/products/menara-ds.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mirror.yaml
+++ b/data/products/mirror.yaml
@@ -12,9 +12,22 @@ categories:
   - CMS
 platforms:
   - tvOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -28,13 +41,3 @@ models:
         billing_basis: per_device
         monthly: 29
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/monitorsanywhere.yaml
+++ b/data/products/monitorsanywhere.yaml
@@ -15,12 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 300000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mood-media.yaml
+++ b/data/products/mood-media.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/moogx.yaml
+++ b/data/products/moogx.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Digital signage for menu boards
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/musthavemenus.yaml
+++ b/data/products/musthavemenus.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Display
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 20
-        yearly: 240
 stats:
   screens:
     total: 10000
@@ -37,3 +26,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Display
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 20
+        yearly: 240

--- a/data/products/mvix.yaml
+++ b/data/products/mvix.yaml
@@ -19,22 +19,6 @@ platforms:
   - iOS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Flex Standard
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 20
-        yearly: null
-      - name: Flex Pro
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 30
-        yearly: null
 stats:
   screens:
     total: 75000
@@ -50,3 +34,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Flex Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 20
+        yearly: null
+      - name: Flex Pro
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 30
+        yearly: null

--- a/data/products/mydia.yaml
+++ b/data/products/mydia.yaml
@@ -11,12 +11,6 @@ discontinued: true
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mysignageportal.yaml
+++ b/data/products/mysignageportal.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/mysvd.yaml
+++ b/data/products/mysvd.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starting price
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 67
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starting price
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 67
+        yearly: null

--- a/data/products/myvideospot.yaml
+++ b/data/products/myvideospot.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Web Browser
   - iOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/nanonation-commandpoint.yaml
+++ b/data/products/nanonation-commandpoint.yaml
@@ -18,12 +18,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 100000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/navigo.yaml
+++ b/data/products/navigo.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/navori.yaml
+++ b/data/products/navori.yaml
@@ -20,17 +20,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Cloud Essential
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 14
-        yearly: null
 stats:
   screens:
     total: 40000
@@ -45,3 +34,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Cloud Essential
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 14
+        yearly: null

--- a/data/products/nento.yaml
+++ b/data/products/nento.yaml
@@ -1,6 +1,8 @@
 name: nento
 slug: nento
-description: Digital signage software for distributing apps, integrations, and live content to single or multiple workplace screens.
+description: >-
+  Digital signage software for distributing apps, integrations, and live content to single or multiple workplace
+  screens.
 website: https://nento.com/
 year_founded: 2015
 headquarters:
@@ -17,12 +19,6 @@ platforms:
   - Roku OS
   - iOS
   - tvOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - webOS and Tizen are planned to be added
@@ -34,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/neon.yaml
+++ b/data/products/neon.yaml
@@ -16,17 +16,6 @@ platforms:
   - Fire OS
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Digital Signage
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 35
-        yearly: 360
 stats: {}
 notes: []
 features: []
@@ -37,3 +26,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Digital Signage
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 35
+        yearly: 360

--- a/data/products/neoscreen.yaml
+++ b/data/products/neoscreen.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/neotess.yaml
+++ b/data/products/neotess.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 7500
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/neovo-signage.yaml
+++ b/data/products/neovo-signage.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/netplay.yaml
+++ b/data/products/netplay.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/netpresenter.yaml
+++ b/data/products/netpresenter.yaml
@@ -17,12 +17,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/netvisual.yaml
+++ b/data/products/netvisual.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/newvision.yaml
+++ b/data/products/newvision.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 6000
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/nixplay.yaml
+++ b/data/products/nixplay.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Built-in, Complete Signage Software
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 19.99
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Built-in, Complete Signage Software
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 19.99
+        yearly: null

--- a/data/products/nonius.yaml
+++ b/data/products/nonius.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Web Browser
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Digital signage solution for hotels.
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/notice-signage.yaml
+++ b/data/products/notice-signage.yaml
@@ -13,15 +13,9 @@ categories:
   - CMS
 platforms:
   - Tizen
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
-  - "Acquired by and merged into mCubeDigital."
+  - Acquired by and merged into mCubeDigital.
 features: []
 integrations: []
 target_audience: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/novacloud.yaml
+++ b/data/products/novacloud.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - NovaStar
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 1000000
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/noventri.yaml
+++ b/data/products/noventri.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/novisign.yaml
+++ b/data/products/novisign.yaml
@@ -19,17 +19,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 20
-        yearly: 216
 stats:
   screens:
     total: 50000
@@ -44,3 +33,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 20
+        yearly: 216

--- a/data/products/novods.yaml
+++ b/data/products/novods.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/nowsignage.yaml
+++ b/data/products/nowsignage.yaml
@@ -22,17 +22,6 @@ platforms:
   - Web Browser
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: End User Pricing
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 20
-        yearly: null
 stats:
   screens:
     total: 5000
@@ -48,3 +37,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: End User Pricing
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 20
+        yearly: null

--- a/data/products/nsigntv.yaml
+++ b/data/products/nsigntv.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 50000
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/numia.yaml
+++ b/data/products/numia.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/nusyn.yaml
+++ b/data/products/nusyn.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - ChromeOS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/nutrislice.yaml
+++ b/data/products/nutrislice.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 30000
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/nuvelar-display.yaml
+++ b/data/products/nuvelar-display.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/obscreen.yaml
+++ b/data/products/obscreen.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Linux
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Basic Cloud
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 3.43
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Basic Cloud
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 3.43
+        yearly: null

--- a/data/products/ommasign.yaml
+++ b/data/products/ommasign.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 12000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/omnivex.yaml
+++ b/data/products/omnivex.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/one-ds.yaml
+++ b/data/products/one-ds.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/oneblending.yaml
+++ b/data/products/oneblending.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/oneview.yaml
+++ b/data/products/oneview.yaml
@@ -1,6 +1,8 @@
 name: OneView
 slug: oneview
-description: Digital signage CMS for creating and managing advertising content on display panels across retail and service locations.
+description: >-
+  Digital signage CMS for creating and managing advertising content on display panels across retail and service
+  locations.
 website: https://oneview.rs/en/
 year_founded: 2009
 headquarters:
@@ -14,12 +16,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/onq-cms.yaml
+++ b/data/products/onq-cms.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/onsign-tv.yaml
+++ b/data/products/onsign-tv.yaml
@@ -23,17 +23,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Professional
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 19.99
-        yearly: 215.88
 stats: {}
 notes: []
 features: []
@@ -44,3 +33,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Professional
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 19.99
+        yearly: 215.88

--- a/data/products/opensign.yaml
+++ b/data/products/opensign.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/opensignage.yaml
+++ b/data/products/opensignage.yaml
@@ -14,17 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: CMS Subscription
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 23.5
-        yearly: 254
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: CMS Subscription
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 23.5
+        yearly: 254

--- a/data/products/optisigns.yaml
+++ b/data/products/optisigns.yaml
@@ -24,22 +24,6 @@ platforms:
   - tvOS
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Free
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-      - name: Standard
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: 108
 stats:
   screens:
     total: 175605
@@ -54,3 +38,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: 108

--- a/data/products/oscart.yaml
+++ b/data/products/oscart.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 12253
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ozonet.yaml
+++ b/data/products/ozonet.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/pads4.yaml
+++ b/data/products/pads4.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Crestron AirMedia
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 16000
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/peaksignage.yaml
+++ b/data/products/peaksignage.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/philips-cmnd.yaml
+++ b/data/products/philips-cmnd.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/piads.yaml
+++ b/data/products/piads.yaml
@@ -1,31 +1,21 @@
 name: PiAds
 slug: piads
 description: ""
-website: "https://www.piads.co/"
+website: https://www.piads.co/
 year_founded: 2025
-headquarters: ["USA"]
+headquarters:
+  - USA
 open_source: false
 rss_feed_url: null
 self_signup: true
 discontinued: false
-categories: ["CMS"]
-platforms: [
-  "Raspberry Pi",
-  "Web Browser",
-  "Android",
-  "Fire OS",
-]
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: "Community Plan"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: null
+categories:
+  - CMS
+platforms:
+  - Raspberry Pi
+  - Web Browser
+  - Android
+  - Fire OS
 stats: {}
 notes: []
 features: []
@@ -36,3 +26,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Community Plan
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: null

--- a/data/products/pickcel.yaml
+++ b/data/products/pickcel.yaml
@@ -22,17 +22,6 @@ platforms:
   - Tizen
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Professional
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 15
-        yearly: 162
 stats:
   screens:
     total: 100000
@@ -48,3 +37,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Professional
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 15
+        yearly: 162

--- a/data/products/pictor.yaml
+++ b/data/products/pictor.yaml
@@ -15,9 +15,23 @@ platforms:
   - Android
   - Fire OS
   - Windows
+stats: {}
+notes:
+  - "Two purchase methods: subscription and one-time license payment that includes 1 year remote management"
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -41,14 +55,3 @@ models:
         billing_basis: per_device
         monthly: 32
         yearly: null
-stats: {}
-notes:
-  - "Two purchase methods: subscription and one-time license payment that includes 1 year remote management"
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/picturemachine4.yaml
+++ b/data/products/picturemachine4.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/pilottv.yaml
+++ b/data/products/pilottv.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 7000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/pisignage.yaml
+++ b/data/products/pisignage.yaml
@@ -21,24 +21,15 @@ platforms:
   - Linux
   - Raspberry Pi
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 1.67
-        yearly: 1.67
 stats:
   screens:
     total: 125493
     source: https://pisignage.com/homepage/index.html
     date: 2025-04
 notes:
-  - A player license is required for open-source server usage, though subscription charges are waived if opting for an open-source server.
+  - >-
+    A player license is required for open-source server usage, though subscription charges are waived if opting for an
+    open-source server.
 features: []
 integrations: []
 target_audience: []
@@ -47,3 +38,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 1.67
+        yearly: 1.67

--- a/data/products/pixelnebula.yaml
+++ b/data/products/pixelnebula.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/pixilab-blocks.yaml
+++ b/data/products/pixilab-blocks.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/playengo.yaml
+++ b/data/products/playengo.yaml
@@ -11,12 +11,6 @@ discontinued: true
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/playipp.yaml
+++ b/data/products/playipp.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: PLAYipp digital signage platform
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 27
-        yearly: null
 stats:
   screens:
     total: 22000
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: PLAYipp digital signage platform
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 27
+        yearly: null

--- a/data/products/playshield.yaml
+++ b/data/products/playshield.yaml
@@ -19,17 +19,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Cloud
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5
-        yearly: null
 stats:
   screens:
     total: 5000
@@ -44,3 +33,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Cloud
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5
+        yearly: null

--- a/data/products/playsignage.yaml
+++ b/data/products/playsignage.yaml
@@ -24,17 +24,6 @@ platforms:
   - Windows
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Subscription
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 18
-        yearly: 144
 stats:
   screens:
     total: 17000
@@ -49,3 +38,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Subscription
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 18
+        yearly: 144

--- a/data/products/plustv.yaml
+++ b/data/products/plustv.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/poppulo.yaml
+++ b/data/products/poppulo.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 500000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/posterbooking.yaml
+++ b/data/products/posterbooking.yaml
@@ -18,24 +18,15 @@ platforms:
   - Raspberry Pi
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Home Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 6.49
-        yearly: null
 stats:
   screens:
     total: 35000
     source: https://posterbooking.com/
     date: 2025-04
 notes:
-  - We mention a minimum of 35000 connected screens based on customer count, but the actual number could be significantly higher.
+  - >-
+    We mention a minimum of 35000 connected screens based on customer count, but the actual number could be
+    significantly higher.
 features: []
 integrations: []
 target_audience: []
@@ -44,3 +35,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Home Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 6.49
+        yearly: null

--- a/data/products/professional-signs.yaml
+++ b/data/products/professional-signs.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/progic.yaml
+++ b/data/products/progic.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 7000
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/prtv.yaml
+++ b/data/products/prtv.yaml
@@ -1,6 +1,8 @@
 name: PRTV
 slug: prtv
-description: Online slideshow builder for Smart TV and Android TV with remote content management for retail, pharmacies, and salons.
+description: >-
+  Online slideshow builder for Smart TV and Android TV with remote content management for retail, pharmacies, and
+  salons.
 website: https://s.prtv.su/
 year_founded: 2019
 headquarters:
@@ -14,12 +16,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/publicview.yaml
+++ b/data/products/publicview.yaml
@@ -15,9 +15,23 @@ platforms:
   - Fire OS
   - Windows
   - webOS
+stats: {}
+notes:
+  - One time start-up fee of $109.9 is not included in the subcription price.
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: false
     pricing:
@@ -36,14 +50,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 624
-stats: {}
-notes:
-  - One time start-up fee of $109.9 is not included in the subcription price.
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/pyrosign.yaml
+++ b/data/products/pyrosign.yaml
@@ -13,9 +13,22 @@ categories:
 platforms:
   - Raspberry Pi
   - Web Browser
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -39,13 +52,3 @@ models:
         billing_basis: per_device
         monthly: 14
         yearly: 168
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/q-play.yaml
+++ b/data/products/q-play.yaml
@@ -17,17 +17,6 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Lite
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 13.8
-        yearly: 138
 stats:
   screens:
     total: 5000
@@ -43,3 +32,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Lite
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 13.8
+        yearly: 138

--- a/data/products/qmatic-display.yaml
+++ b/data/products/qmatic-display.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/quickesign.yaml
+++ b/data/products/quickesign.yaml
@@ -16,9 +16,22 @@ platforms:
   - Fire OS
   - Raspberry Pi
   - Roku OS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -42,13 +55,3 @@ models:
         billing_basis: per_device
         monthly: 20
         yearly: 199
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/quicksign.yaml
+++ b/data/products/quicksign.yaml
@@ -14,9 +14,22 @@ categories:
 platforms:
   - Android
   - Fire OS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: false
     pricing:
@@ -30,13 +43,3 @@ models:
         billing_basis: per_device
         monthly: 20
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/radix.yaml
+++ b/data/products/radix.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/raspberry-digital-signage.yaml
+++ b/data/products/raspberry-digital-signage.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Raspberry Pi
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/reach.yaml
+++ b/data/products/reach.yaml
@@ -11,20 +11,8 @@ self_signup: false
 discontinued: false
 categories:
   - CMS
-platforms: [
-  "Amazon Signage"
-]
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Pro Plam
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 19.99
-        yearly: null
+platforms:
+  - Amazon Signage
 stats:
   screens:
     total: 40000
@@ -39,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Pro Plam
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 19.99
+        yearly: null

--- a/data/products/redyref-engage.yaml
+++ b/data/products/redyref-engage.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/reflect-adlogic.yaml
+++ b/data/products/reflect-adlogic.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Digital advertising solution designed specifically for the unique needs of the place-based and out-of-home markets.
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/reflect-experience.yaml
+++ b/data/products/reflect-experience.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/reflectview.yaml
+++ b/data/products/reflectview.yaml
@@ -15,12 +15,6 @@ platforms:
   - BrightSign
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 400000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/repeat-signage.yaml
+++ b/data/products/repeat-signage.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Repeat Signage V5 Standard Edition
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 172.5
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Repeat Signage V5 Standard Edition
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 172.5

--- a/data/products/retailrotor.yaml
+++ b/data/products/retailrotor.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Small business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 8.2
-        yearly: null
 stats:
   screens:
     total: 50000
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Small business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 8.2
+        yearly: null

--- a/data/products/retriever-digital-signage.yaml
+++ b/data/products/retriever-digital-signage.yaml
@@ -12,17 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Subscription
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 99
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Subscription
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 99
+        yearly: null

--- a/data/products/revel-digital.yaml
+++ b/data/products/revel-digital.yaml
@@ -19,12 +19,6 @@ platforms:
   - Linux
   - Raspberry Pi
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/rise-vision.yaml
+++ b/data/products/rise-vision.yaml
@@ -22,17 +22,6 @@ platforms:
   - Windows
   - tvOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 12
-        yearly: 132
 stats:
   screens:
     total: 60892
@@ -47,3 +36,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 12
+        yearly: 132

--- a/data/products/rockbot.yaml
+++ b/data/products/rockbot.yaml
@@ -16,17 +16,6 @@ platforms:
   - BrightSign
   - Fire OS
   - Tizen
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Digital Signage
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 30
-        yearly: 300
 stats: {}
 notes: []
 features: []
@@ -37,3 +26,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Digital Signage
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 30
+        yearly: 300

--- a/data/products/rs-cms.yaml
+++ b/data/products/rs-cms.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Web Browser
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/rt-screens.yaml
+++ b/data/products/rt-screens.yaml
@@ -19,17 +19,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Без видеоаналитики
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10.5
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -40,3 +29,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Без видеоаналитики
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10.5
+        yearly: null

--- a/data/products/ryarc-campaignmanager.yaml
+++ b/data/products/ryarc-campaignmanager.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - A single platform for managing digital signage, audio, and sensors.
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/sabercom.yaml
+++ b/data/products/sabercom.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/sageview.yaml
+++ b/data/products/sageview.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 430000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/saii.yaml
+++ b/data/products/saii.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/salute-screens.yaml
+++ b/data/products/salute-screens.yaml
@@ -19,17 +19,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Без видеоаналитики
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10.5
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -40,3 +29,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Без видеоаналитики
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10.5
+        yearly: null

--- a/data/products/samsung-vxt.yaml
+++ b/data/products/samsung-vxt.yaml
@@ -15,17 +15,6 @@ platforms:
   - Fire OS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: S Series
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 20
-        yearly: 200
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: S Series
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 20
+        yearly: 200

--- a/data/products/sandisplay.yaml
+++ b/data/products/sandisplay.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Tizen
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/scala.yaml
+++ b/data/products/scala.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 3100000
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/scalefusion.yaml
+++ b/data/products/scalefusion.yaml
@@ -18,9 +18,22 @@ platforms:
   - Windows
   - iOS
   - macOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -44,13 +57,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 72
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/sceo.yaml
+++ b/data/products/sceo.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/school-informator.yaml
+++ b/data/products/school-informator.yaml
@@ -17,12 +17,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/screen-canvas.yaml
+++ b/data/products/screen-canvas.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - tvOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Pro
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: null
 stats: {}
 notes:
   - Digital signage software for Apple TV with no subscription
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Pro
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: null

--- a/data/products/screen-publishing.yaml
+++ b/data/products/screen-publishing.yaml
@@ -17,12 +17,6 @@ platforms:
   - Fire OS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/screen2b.yaml
+++ b/data/products/screen2b.yaml
@@ -13,9 +13,22 @@ categories:
   - CMS
 platforms:
   - Web Browser
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -34,13 +47,3 @@ models:
         billing_basis: per_device
         monthly: 6.4
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/screenberry.yaml
+++ b/data/products/screenberry.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/screencloud.yaml
+++ b/data/products/screencloud.yaml
@@ -20,17 +20,6 @@ platforms:
   - Windows
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Core
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 24
-        yearly: 240
 stats:
   screens:
     total: 100000
@@ -45,3 +34,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Core
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 24
+        yearly: 240

--- a/data/products/screendrive.yaml
+++ b/data/products/screendrive.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 1500
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/screenfeed.yaml
+++ b/data/products/screenfeed.yaml
@@ -1,6 +1,8 @@
 name: Screenfeed
 slug: screenfeed
-description: Digital signage content provider offering licensed weather, news, sports, financial data, and custom data-driven content.
+description: >-
+  Digital signage content provider offering licensed weather, news, sports, financial data, and custom data-driven
+  content.
 website: https://www.screenfeed.com/
 year_founded: 1999
 headquarters:
@@ -11,12 +13,6 @@ discontinued: false
 categories:
   - Content provider
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 150000
@@ -32,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/screenfluence.yaml
+++ b/data/products/screenfluence.yaml
@@ -12,17 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: 1 - 9 Players
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 30
-        yearly: 324
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 1 - 9 Players
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 30
+        yearly: 324

--- a/data/products/screenivo.yaml
+++ b/data/products/screenivo.yaml
@@ -1,36 +1,22 @@
 name: Screenivo
 slug: screenivo
-description: "The digital signage tool built for cafes, retail, offices, and beyond. Set up in minutes, no technical skills or special hardware needed. First screen is free."
+description: >-
+  The digital signage tool built for cafes, retail, offices, and beyond. Set up in minutes, no technical skills or
+  special hardware needed. First screen is free.
 website: https://screenivo.com/
 year_founded: 2026
 headquarters:
-    - "Czech Republic"
+  - Czech Republic
 open_source: false
 rss_feed_url: null
 self_signup: true
 discontinued: false
 categories:
-    - CMS
+  - CMS
 platforms:
-    - Web Browser
-    - Android
-    - Fire OS
-models:
-    - delivery: cloud
-      free_trial: false
-      pricing_available: true
-      has_freemium: true
-      pricing:
-        - name: Free (1 screen included)
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 0
-          yearly: null
-        - name: Additional Screens
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 5
-          yearly: null
+  - Web Browser
+  - Android
+  - Fire OS
 stats: {}
 notes: []
 features: []
@@ -43,4 +29,23 @@ screenshots: []
 last_verified: "2026-04-16"
 has_sso: true
 has_api: true
-developer_portal_url: "https://screenivo.com/"
+developer_portal_url: https://screenivo.com/
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free (1 screen included)
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: null
+      - name: Additional Screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5
+        yearly: null

--- a/data/products/screenlite.yaml
+++ b/data/products/screenlite.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/screenly.yaml
+++ b/data/products/screenly.yaml
@@ -26,9 +26,26 @@ platforms:
   - Tizen
   - Web Browser
   - webOS
+stats:
+  screens:
+    total: 10000
+    source: https://www.screenly.io/
+    date: 2025-04
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -47,17 +64,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 300
-stats:
-  screens:
-    total: 10000
-    source: https://www.screenly.io/
-    date: 2025-04
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/screenmanager.yaml
+++ b/data/products/screenmanager.yaml
@@ -21,17 +21,6 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 8
-        yearly: 72
 stats:
   screens:
     total: 9345
@@ -46,3 +35,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 8
+        yearly: 72

--- a/data/products/screensoft.yaml
+++ b/data/products/screensoft.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Video demo of the software is available.
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/screentinker.yaml
+++ b/data/products/screentinker.yaml
@@ -1,6 +1,8 @@
 name: ScreenTinker
 slug: screentinker
-description: Open-source digital signage platform for remote management of content across multiple displays, with scheduling, video walls, and real-time monitoring.
+description: >-
+  Open-source digital signage platform for remote management of content across multiple displays, with scheduling, video
+  walls, and real-time monitoring.
 website: https://screentinker.com
 year_founded: 2026
 headquarters:
@@ -20,9 +22,22 @@ platforms:
   - Raspberry Pi
   - Web Browser
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: true
+  self_hosted: true
 models:
-  - delivery: hybrid
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -46,18 +61,3 @@ models:
         billing_basis: flat_rate
         monthly: 199
         yearly: 1989
-  - delivery: self-hosted
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/sdbcomplex.yaml
+++ b/data/products/sdbcomplex.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 7135
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/sedco.yaml
+++ b/data/products/sedco.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/sedna-cloud.yaml
+++ b/data/products/sedna-cloud.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/seencmp.yaml
+++ b/data/products/seencmp.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/sensorylab.yaml
+++ b/data/products/sensorylab.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/shop-iq.yaml
+++ b/data/products/shop-iq.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 7300
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/sign-presenter.yaml
+++ b/data/products/sign-presenter.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Per screen
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Per screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: null

--- a/data/products/signa.yaml
+++ b/data/products/signa.yaml
@@ -18,9 +18,22 @@ platforms:
   - Windows
   - iOS
   - macOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -44,13 +57,3 @@ models:
         billing_basis: per_device
         monthly: 8
         yearly: 84
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/signage-ninja.yaml
+++ b/data/products/signage-ninja.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - ChromeOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - By TRISON
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signage-orchestrator.yaml
+++ b/data/products/signage-orchestrator.yaml
@@ -13,12 +13,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/signage-pilot.yaml
+++ b/data/products/signage-pilot.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signage-plus.yaml
+++ b/data/products/signage-plus.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signage-rocket.yaml
+++ b/data/products/signage-rocket.yaml
@@ -15,17 +15,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: All-inclusive
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 25
-        yearly: 249
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: All-inclusive
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 25
+        yearly: 249

--- a/data/products/signage-soft.yaml
+++ b/data/products/signage-soft.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signage-space.yaml
+++ b/data/products/signage-space.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/signage-studio.yaml
+++ b/data/products/signage-studio.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signagecontrol.yaml
+++ b/data/products/signagecontrol.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signagect.yaml
+++ b/data/products/signagect.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signageflow.yaml
+++ b/data/products/signageflow.yaml
@@ -1,33 +1,18 @@
-name: "SignageFlow"
+name: SignageFlow
 slug: signageflow
 description: ""
-website: "https://signageflow.com/"
+website: https://signageflow.com/
 year_founded: 2025
-headquarters: ["UAE"]
+headquarters:
+  - UAE
 open_source: false
 rss_feed_url: null
 self_signup: true
 discontinued: false
-categories: ["CMS"]
-platforms: [
-  "Web Browser",
-]
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: "5 screen Pack"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 15
-        yearly: 150
-      - name: "10 Screen pack"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 30
-        yearly: 299
+categories:
+  - CMS
+platforms:
+  - Web Browser
 stats: {}
 notes: []
 features: []
@@ -38,3 +23,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 5 screen Pack
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 15
+        yearly: 150
+      - name: 10 Screen pack
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 30
+        yearly: 299

--- a/data/products/signagego.yaml
+++ b/data/products/signagego.yaml
@@ -18,12 +18,6 @@ platforms:
   - Linux
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signagelive.yaml
+++ b/data/products/signagelive.yaml
@@ -18,17 +18,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Standard license
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 270
 stats:
   screens:
     total: 10000
@@ -43,3 +32,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Standard license
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 270

--- a/data/products/signagemx.yaml
+++ b/data/products/signagemx.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signagenow.yaml
+++ b/data/products/signagenow.yaml
@@ -1,6 +1,8 @@
 name: SignageNow Digital Signage Software
 slug: signagenow
-description: Free cloud digital signage software that lets users manage displays directly from a browser without extra hardware. Self-service sign-up with no credit card required.
+description: >-
+  Free cloud digital signage software that lets users manage displays directly from a browser without extra hardware.
+  Self-service sign-up with no credit card required.
 website: https://www.signagenow.tv
 year_founded: 2026
 headquarters:
@@ -23,12 +25,6 @@ platforms:
   - Web Browser
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -39,3 +35,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/signageos.yaml
+++ b/data/products/signageos.yaml
@@ -18,17 +18,6 @@ platforms:
   - Linux
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 3
-        yearly: null
 stats:
   screens:
     total: 100000
@@ -43,3 +32,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 3
+        yearly: null

--- a/data/products/signagetube.yaml
+++ b/data/products/signagetube.yaml
@@ -16,17 +16,6 @@ platforms:
   - Fire OS
   - Windows
   - tvOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Premium
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 19
-        yearly: 168
 stats:
   screens:
     total: 10000
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Premium
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 19
+        yearly: 168

--- a/data/products/signao.yaml
+++ b/data/products/signao.yaml
@@ -16,9 +16,22 @@ platforms:
   - Tizen
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: false
     pricing:
@@ -42,13 +55,3 @@ models:
         billing_basis: per_device
         monthly: 33
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/signboox.yaml
+++ b/data/products/signboox.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signcast.yaml
+++ b/data/products/signcast.yaml
@@ -16,17 +16,6 @@ platforms:
   - ChromeOS
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Studio
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 216
 stats: {}
 notes:
   - Seems like NoviSign white-label
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Studio
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 216

--- a/data/products/signcloud.yaml
+++ b/data/products/signcloud.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signera.yaml
+++ b/data/products/signera.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signet.yaml
+++ b/data/products/signet.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signio.yaml
+++ b/data/products/signio.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 120000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/signmate.yaml
+++ b/data/products/signmate.yaml
@@ -15,9 +15,22 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -31,13 +44,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 182
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/signmenu.yaml
+++ b/data/products/signmenu.yaml
@@ -12,9 +12,22 @@ discontinued: false
 categories:
   - CMS
 platforms: []
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -28,13 +41,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 499
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/signstix.yaml
+++ b/data/products/signstix.yaml
@@ -15,12 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/simplesignage.yaml
+++ b/data/products/simplesignage.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - tvOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Site License
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 250
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Site License
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 250

--- a/data/products/sippo.yaml
+++ b/data/products/sippo.yaml
@@ -14,9 +14,23 @@ platforms:
   - Amazon Signage
   - Android
   - Fire OS
+stats: {}
+notes:
+  - Digital Menu Boards
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -35,14 +49,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 384
-stats: {}
-notes:
-  - Digital Menu Boards
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/sitekiosk.yaml
+++ b/data/products/sitekiosk.yaml
@@ -15,17 +15,6 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Online Cloud
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 272.46
 stats:
   screens:
     total: 10000
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Online Cloud
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 272.46

--- a/data/products/sklera.yaml
+++ b/data/products/sklera.yaml
@@ -19,9 +19,26 @@ platforms:
   - Tizen
   - Windows
   - webOS
+stats:
+  screens:
+    total: 1000
+    source: https://sklera.tv/en/about-us
+    date: 2017-01
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -40,17 +57,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 360
-stats:
-  screens:
-    total: 1000
-    source: https://sklera.tv/en/about-us
-    date: 2017-01
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/skoop.yaml
+++ b/data/products/skoop.yaml
@@ -21,9 +21,22 @@ platforms:
   - Windows
   - iOS
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -37,13 +50,3 @@ models:
         billing_basis: per_device
         monthly: 20
         yearly: 216
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/skratch.yaml
+++ b/data/products/skratch.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 11641
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/skykit.yaml
+++ b/data/products/skykit.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Base
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 16.5
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Base
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 16.5
+        yearly: null

--- a/data/products/skymedia.yaml
+++ b/data/products/skymedia.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - One-time charge without subscription.
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/skysignage.yaml
+++ b/data/products/skysignage.yaml
@@ -16,12 +16,6 @@ platforms:
   - Tizen
   - iiyama
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/slideshow.yaml
+++ b/data/products/slideshow.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: App
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
 stats:
   screens:
     total: 19000
@@ -39,3 +28,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: App
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0

--- a/data/products/smart-media-control.yaml
+++ b/data/products/smart-media-control.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/smart-prospective.yaml
+++ b/data/products/smart-prospective.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Cloud
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 56.26
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Cloud
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 56.26
+        yearly: null

--- a/data/products/smartersign.yaml
+++ b/data/products/smartersign.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Small Business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 30
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Small Business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 30
+        yearly: null

--- a/data/products/smartinfo.yaml
+++ b/data/products/smartinfo.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/smartplayer.yaml
+++ b/data/products/smartplayer.yaml
@@ -20,12 +20,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 50000
@@ -40,3 +34,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/smartsign.yaml
+++ b/data/products/smartsign.yaml
@@ -19,12 +19,6 @@ platforms:
   - Windows
   - iiyama
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - The first release notes are available from 2020
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/smartsign2go.yaml
+++ b/data/products/smartsign2go.yaml
@@ -19,9 +19,26 @@ platforms:
   - Windows
   - iOS
   - macOS
+stats:
+  screens:
+    total: 10000
+    source: https://smartsign2go.com/life-with-us/about-us/
+    date: 2025-04
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -40,17 +57,3 @@ models:
         billing_basis: per_device
         monthly: 43
         yearly: null
-stats:
-  screens:
-    total: 10000
-    source: https://smartsign2go.com/life-with-us/about-us/
-    date: 2025-04
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/smilcontrol.yaml
+++ b/data/products/smilcontrol.yaml
@@ -16,17 +16,6 @@ platforms:
   - Linux
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Sample Offer
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5.7
-        yearly: null
 stats: {}
 notes:
   - A CMS that can be used with the open-source digital signage player Garlic Player
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Sample Offer
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5.7
+        yearly: null

--- a/data/products/snapcomms.yaml
+++ b/data/products/snapcomms.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/socialwalls.yaml
+++ b/data/products/socialwalls.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - Content provider
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing: []

--- a/data/products/sodaclick.yaml
+++ b/data/products/sodaclick.yaml
@@ -20,12 +20,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/solix.yaml
+++ b/data/products/solix.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/spectrio.yaml
+++ b/data/products/spectrio.yaml
@@ -19,12 +19,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 150000
@@ -40,3 +34,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/spectroo.yaml
+++ b/data/products/spectroo.yaml
@@ -16,17 +16,6 @@ platforms:
   - Linux
   - Raspberry Pi
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: "Standard: 1-29 screens"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 20
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -37,3 +26,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: "Standard: 1-29 screens"
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 20
+        yearly: null

--- a/data/products/spinetix-arya.yaml
+++ b/data/products/spinetix-arya.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/spinetix-elementi.yaml
+++ b/data/products/spinetix-elementi.yaml
@@ -1,6 +1,8 @@
 name: SpinetiX Elementi
 slug: spinetix-elementi
-description: Digital signage software for displaying visual content on screens, video walls, and interactive terminals with live streaming.
+description: >-
+  Digital signage software for displaying visual content on screens, video walls, and interactive terminals with live
+  streaming.
 website: https://www.spinetix.com/digital-signage-products/elementi
 year_founded: 2017
 headquarters:
@@ -11,12 +13,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/splashtiles.yaml
+++ b/data/products/splashtiles.yaml
@@ -14,17 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Raspberry Pi
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Lite
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 25
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Lite
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 25

--- a/data/products/squizz.yaml
+++ b/data/products/squizz.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Individual
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 4.99
-        yearly: 49.99
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Individual
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 4.99
+        yearly: 49.99

--- a/data/products/st-digital.yaml
+++ b/data/products/st-digital.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/stino-ichannel.yaml
+++ b/data/products/stino-ichannel.yaml
@@ -18,12 +18,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/strandvision.yaml
+++ b/data/products/strandvision.yaml
@@ -14,9 +14,22 @@ platforms:
   - Linux
   - Windows
   - macOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -30,13 +43,3 @@ models:
         billing_basis: per_device
         monthly: 41.6
         yearly: 499.99
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/stratacache.yaml
+++ b/data/products/stratacache.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 4000000
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/stratosmedia.yaml
+++ b/data/products/stratosmedia.yaml
@@ -19,15 +19,11 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
-  - StratosMedia also delivers its proprietary Operating System – StratosOS which can be loaded on any x86-64 hardware to create a StratosMedia playback device.
+  - >-
+    StratosMedia also delivers its proprietary Operating System – StratosOS which can be loaded on any x86-64 hardware
+    to create a StratosMedia playback device.
 features: []
 integrations: []
 target_audience: []
@@ -36,3 +32,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/studiolite.yaml
+++ b/data/products/studiolite.yaml
@@ -11,12 +11,6 @@ discontinued: true
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/studiopro.yaml
+++ b/data/products/studiopro.yaml
@@ -14,17 +14,6 @@ categories:
 platforms:
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Per screen
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Per screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: null

--- a/data/products/studioweb.yaml
+++ b/data/products/studioweb.yaml
@@ -13,17 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Per screen
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Per screen
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: null

--- a/data/products/supacms.yaml
+++ b/data/products/supacms.yaml
@@ -1,39 +1,25 @@
-name: "Supacms"
+name: Supacms
 slug: supacms
 description: ""
-website: "https://supacms.metaworcs.com/"
+website: https://supacms.metaworcs.com/
 year_founded: 2025
-headquarters: ["Pakistan"]
+headquarters:
+  - Pakistan
 open_source: false
 rss_feed_url: null
 self_signup: true
 discontinued: false
-categories: ["CMS"]
+categories:
+  - CMS
 platforms:
-    - "Web Browser"
-    - "Android"
-    - Fire OS
-models:
-    - delivery: cloud
-      free_trial: true
-      pricing_available: true
-      has_freemium: false
-      pricing:
-        - name: "Standard"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 7
-          yearly: 70
-        - name: "PRO"
-          payment_model: subscription
-          billing_basis: per_device
-          monthly: 14
-          yearly: 140
+  - Web Browser
+  - Android
+  - Fire OS
 stats:
-    screens:
-        total: 1000
-        source: https://supacms.metaworcs.com/
-        date: 2026-03
+  screens:
+    total: 1000
+    source: https://supacms.metaworcs.com/
+    date: 2026-03
 notes: []
 features: []
 integrations: []
@@ -43,3 +29,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 7
+        yearly: 70
+      - name: PRO
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 14
+        yearly: 140

--- a/data/products/superbolt.yaml
+++ b/data/products/superbolt.yaml
@@ -12,17 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: SMB
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: null
-        yearly: 149
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: SMB
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: null
+        yearly: 149

--- a/data/products/surevideo.yaml
+++ b/data/products/surevideo.yaml
@@ -15,9 +15,23 @@ platforms:
   - Fire OS
   - Windows
   - iOS
+stats: {}
+notes:
+  - a digital signage kiosk solution
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -31,14 +45,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 29.99
-stats: {}
-notes:
-  - a digital signage kiosk solution
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/surspb.yaml
+++ b/data/products/surspb.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/switchboard.yaml
+++ b/data/products/switchboard.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/szcope.yaml
+++ b/data/products/szcope.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/targetr.yaml
+++ b/data/products/targetr.yaml
@@ -14,17 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: 50 screens
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 8
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -35,3 +24,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: 50 screens
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 8
+        yearly: null

--- a/data/products/tcadvert.yaml
+++ b/data/products/tcadvert.yaml
@@ -11,15 +11,11 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
-  - IMS has over 4300 digital signage screens installed according to their website; however, not all of them are using their TCadvert software.
+  - >-
+    IMS has over 4300 digital signage screens installed according to their website; however, not all of them are using
+    their TCadvert software.
 features: []
 integrations: []
 target_audience: []
@@ -28,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/tdm-signage.yaml
+++ b/data/products/tdm-signage.yaml
@@ -16,9 +16,22 @@ platforms:
   - Tizen
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -37,13 +50,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 339
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/telefonica-tech.yaml
+++ b/data/products/telefonica-tech.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/telemetrytv.yaml
+++ b/data/products/telemetrytv.yaml
@@ -20,17 +20,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Entry
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 9
-        yearly: 96
 stats: {}
 notes: []
 features: []
@@ -41,3 +30,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Entry
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 9
+        yearly: 96

--- a/data/products/teos.yaml
+++ b/data/products/teos.yaml
@@ -17,17 +17,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Advanced / Control & Scheduling
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 4.87
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -38,3 +27,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Advanced / Control & Scheduling
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 4.87
+        yearly: null

--- a/data/products/tigermeeting.yaml
+++ b/data/products/tigermeeting.yaml
@@ -14,12 +14,6 @@ platforms:
   - Linux
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/tippler-tv.yaml
+++ b/data/products/tippler-tv.yaml
@@ -12,12 +12,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Still WIP, Tizen to be added
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/touchify.yaml
+++ b/data/products/touchify.yaml
@@ -22,12 +22,6 @@ platforms:
   - iOS
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -38,3 +32,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/trilbytv.yaml
+++ b/data/products/trilbytv.yaml
@@ -19,9 +19,25 @@ platforms:
   - iOS
   - macOS
   - tvOS
+stats: {}
+notes:
+  - >-
+    Digital signage for schools mainly, but also offers options per screen for Charity, Voluntary organisation, or
+    Business.
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -35,14 +51,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 2406
-stats: {}
-notes:
-  - Digital signage for schools mainly, but also offers options per screen for Charity, Voluntary organisation, or Business.
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/trillboards.yaml
+++ b/data/products/trillboards.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Earners
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Earners
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0

--- a/data/products/trinax.yaml
+++ b/data/products/trinax.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/troudigital.yaml
+++ b/data/products/troudigital.yaml
@@ -15,17 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Essential
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 21.3
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Essential
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 21.3
+        yearly: null

--- a/data/products/trudigital.yaml
+++ b/data/products/trudigital.yaml
@@ -15,22 +15,6 @@ platforms:
   - Web Browser
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 29
-        yearly: null
-      - name: Pro
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 49
-        yearly: null
 stats:
   screens:
     total: 10000
@@ -46,3 +30,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 29
+        yearly: null
+      - name: Pro
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 49
+        yearly: null

--- a/data/products/tvcast-pro.yaml
+++ b/data/products/tvcast-pro.yaml
@@ -1,6 +1,10 @@
 name: TVCast Pro
 slug: tvcast-pro
-description: "TVCast Pro is Android TV digital signage software for retail stores, restaurants, cafes, F&B chains, franchises, food courts, and multi-outlet operators. It focuses on pilot-first deployments using compatible Android TVs or Android TV boxes, with centralized publishing for menu boards, promo screens, pickup/cashier screens, and multi-store campaign updates."
+description: >-
+  TVCast Pro is Android TV digital signage software for retail stores, restaurants, cafes, F&B chains, franchises, food
+  courts, and multi-outlet operators. It focuses on pilot-first deployments using compatible Android TVs or Android TV
+  boxes, with centralized publishing for menu boards, promo screens, pickup/cashier screens, and multi-store campaign
+  updates.
 website: https://www.wedotool.com/
 year_founded: null
 headquarters:
@@ -15,17 +19,6 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: "Pay-as-you-go"
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 6
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -36,3 +29,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Pay-as-you-go
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 6
+        yearly: null

--- a/data/products/tvlution.yaml
+++ b/data/products/tvlution.yaml
@@ -12,12 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/tvque.yaml
+++ b/data/products/tvque.yaml
@@ -14,9 +14,22 @@ platforms:
   - Fire OS
   - Roku OS
   - Web Browser
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -35,13 +48,3 @@ models:
         billing_basis: per_device
         monthly: 15
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/uniguest-hub.yaml
+++ b/data/products/uniguest-hub.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - An all-in-one solution for digital signage, interactive TV, casting, room signage, and interactive wayfinding.
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/uniguest-mediastar.yaml
+++ b/data/products/uniguest-mediastar.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - MediaStar Systems acquired by Uniguest in November 2022, originally founded in the UK.
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/uniguest-onelan.yaml
+++ b/data/products/uniguest-onelan.yaml
@@ -14,12 +14,6 @@ platforms:
   - BrightSign
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/uniguest-otrum.yaml
+++ b/data/products/uniguest-otrum.yaml
@@ -16,12 +16,6 @@ platforms:
   - Raspberry Pi
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Norwegian hospitality platform acquired by Uniguest in 2022.
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/uniguest-tripleplay.yaml
+++ b/data/products/uniguest-tripleplay.yaml
@@ -14,12 +14,6 @@ platforms:
   - BrightSign
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - IPTV, digital signage, and video streaming software and technology.
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/uniguest.yaml
+++ b/data/products/uniguest.yaml
@@ -19,12 +19,6 @@ platforms:
   - Linux
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 1000000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/uniview.yaml
+++ b/data/products/uniview.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/upshow.yaml
+++ b/data/products/upshow.yaml
@@ -12,17 +12,6 @@ categories:
   - CMS
 platforms:
   - ChromeOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starter
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 50
-        yearly: null
 stats: {}
 notes:
   - Acquired by EverPass Media
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starter
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 50
+        yearly: null

--- a/data/products/urve.yaml
+++ b/data/products/urve.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/usb-slideshow.yaml
+++ b/data/products/usb-slideshow.yaml
@@ -13,17 +13,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Subscription
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 5
-        yearly: 25
 stats: {}
 notes: []
 features: []
@@ -34,3 +23,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Subscription
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 5
+        yearly: 25

--- a/data/products/userful-engage.yaml
+++ b/data/products/userful-engage.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/valotalive.yaml
+++ b/data/products/valotalive.yaml
@@ -1,6 +1,8 @@
 name: Valotalive
 slug: valotalive
-description: Digital signage software for manufacturing and logistics workplaces, displaying real-time data and critical updates on screens.
+description: >-
+  Digital signage software for manufacturing and logistics workplaces, displaying real-time data and critical updates on
+  screens.
 website: https://valota.live/
 year_founded: 2019
 headquarters:
@@ -15,17 +17,6 @@ platforms:
   - ChromeOS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Starter
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10.31
-        yearly: 92
 stats:
   screens:
     total: 100000
@@ -41,3 +32,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Starter
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10.31
+        yearly: 92

--- a/data/products/venus-control-suite.yaml
+++ b/data/products/venus-control-suite.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/vertika.yaml
+++ b/data/products/vertika.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/vibe-fyi.yaml
+++ b/data/products/vibe-fyi.yaml
@@ -18,17 +18,6 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: true
-    pricing:
-      - name: Lite
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
 stats: {}
 notes: []
 features: []
@@ -39,3 +28,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: true
+    pricing:
+      - name: Lite
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0

--- a/data/products/vicont.yaml
+++ b/data/products/vicont.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Linux
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/vidarti.yaml
+++ b/data/products/vidarti.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 4000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/videoinstore.yaml
+++ b/data/products/videoinstore.yaml
@@ -16,12 +16,6 @@ platforms:
   - Fire OS
   - Linux
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 25000
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/videomood.yaml
+++ b/data/products/videomood.yaml
@@ -18,12 +18,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/videri.yaml
+++ b/data/products/videri.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - Android
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/viewneo.yaml
+++ b/data/products/viewneo.yaml
@@ -15,17 +15,6 @@ platforms:
   - Fire OS
   - Windows
   - iOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: viewneo Professional
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 21
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: viewneo Professional
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 21
+        yearly: null

--- a/data/products/vigitsign.yaml
+++ b/data/products/vigitsign.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/virtusignage.yaml
+++ b/data/products/virtusignage.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 3000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/visiobox.yaml
+++ b/data/products/visiobox.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Tizen
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 20000
@@ -35,3 +29,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/visionbox.yaml
+++ b/data/products/visionbox.yaml
@@ -14,9 +14,22 @@ categories:
 platforms:
   - Web Browser
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -30,13 +43,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 17
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/visionboxone.yaml
+++ b/data/products/visionboxone.yaml
@@ -16,9 +16,22 @@ platforms:
   - Web Browser
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: true
     pricing:
@@ -32,13 +45,3 @@ models:
         billing_basis: per_device
         monthly: 14.07
         yearly: 112.53
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/visionboxpro.yaml
+++ b/data/products/visionboxpro.yaml
@@ -12,17 +12,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 46.89
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -33,3 +22,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 46.89
+        yearly: null

--- a/data/products/visionect.yaml
+++ b/data/products/visionect.yaml
@@ -18,9 +18,22 @@ platforms:
   - Windows
   - macOS
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -34,13 +47,3 @@ models:
         billing_basis: per_device
         monthly: null
         yearly: 108
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/visshow.yaml
+++ b/data/products/visshow.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Web Browser
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/visual-art-signage-player.yaml
+++ b/data/products/visual-art-signage-player.yaml
@@ -20,12 +20,6 @@ platforms:
   - Windows
   - iOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 73000
@@ -40,3 +34,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/visuscreen.yaml
+++ b/data/products/visuscreen.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes:
   - Video tutorial is available on the website.
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/vivi.yaml
+++ b/data/products/vivi.yaml
@@ -20,12 +20,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 120000
@@ -41,3 +35,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/vizansign.yaml
+++ b/data/products/vizansign.yaml
@@ -16,12 +16,6 @@ platforms:
   - Linux
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/voome.yaml
+++ b/data/products/voome.yaml
@@ -13,12 +13,6 @@ categories:
   - CMS
 platforms:
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/vsplayer.yaml
+++ b/data/products/vsplayer.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/vuepilot.yaml
+++ b/data/products/vuepilot.yaml
@@ -15,17 +15,6 @@ platforms:
   - Raspberry Pi
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Monthly or Annual license
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: 96
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Monthly or Annual license
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: 96

--- a/data/products/waapiti.yaml
+++ b/data/products/waapiti.yaml
@@ -18,12 +18,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 10000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wallboard.yaml
+++ b/data/products/wallboard.yaml
@@ -1,6 +1,8 @@
 name: Wallboard
 slug: wallboard
-description: Digital signage platform with workflow automation and governance for managing signage across teams in cloud or private cloud.
+description: >-
+  Digital signage platform with workflow automation and governance for managing signage across teams in cloud or private
+  cloud.
 website: https://www.wallboard.us/
 year_founded: 2012
 headquarters:
@@ -17,9 +19,22 @@ platforms:
   - Tizen
   - Windows
   - webOS
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: false
     pricing:
@@ -33,13 +48,3 @@ models:
         billing_basis: per_device
         monthly: 30
         yearly: null
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/wallin-one.yaml
+++ b/data/products/wallin-one.yaml
@@ -17,12 +17,6 @@ platforms:
   - Fire OS
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 2000
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wallsign.yaml
+++ b/data/products/wallsign.yaml
@@ -19,12 +19,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 4000
@@ -39,3 +33,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wand.yaml
+++ b/data/products/wand.yaml
@@ -14,12 +14,6 @@ platforms:
   - ChromeOS
   - Web Browser
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/watchout.yaml
+++ b/data/products/watchout.yaml
@@ -12,12 +12,6 @@ categories:
   - CMS
 platforms:
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -28,3 +22,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/wauly.yaml
+++ b/data/products/wauly.yaml
@@ -16,17 +16,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Professional
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: 110
 stats:
   screens:
     total: 21000
@@ -42,3 +31,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Professional
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: 110

--- a/data/products/weivit.yaml
+++ b/data/products/weivit.yaml
@@ -10,12 +10,6 @@ discontinued: true
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -26,3 +20,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wejha.yaml
+++ b/data/products/wejha.yaml
@@ -15,17 +15,6 @@ platforms:
   - Fire OS
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 8
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -36,3 +25,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 8
+        yearly: null

--- a/data/products/wesion.yaml
+++ b/data/products/wesion.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wesual.yaml
+++ b/data/products/wesual.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wicanvas.yaml
+++ b/data/products/wicanvas.yaml
@@ -15,12 +15,6 @@ platforms:
   - Fire OS
   - Web Browser
   - iOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wilyer.yaml
+++ b/data/products/wilyer.yaml
@@ -19,17 +19,6 @@ platforms:
   - Windows
   - macOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Pro
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 15
-        yearly: 150
 stats:
   screens:
     total: 20700
@@ -44,3 +33,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Pro
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 15
+        yearly: 150

--- a/data/products/windowsight.yaml
+++ b/data/products/windowsight.yaml
@@ -18,12 +18,6 @@ platforms:
   - iOS
   - tvOS
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: true
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: true
+    pricing: []

--- a/data/products/wioplex.yaml
+++ b/data/products/wioplex.yaml
@@ -20,12 +20,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -36,3 +30,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/worldvds.yaml
+++ b/data/products/worldvds.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 11000
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/wovenmanager.yaml
+++ b/data/products/wovenmanager.yaml
@@ -16,12 +16,6 @@ platforms:
   - BrightSign
   - ChromeOS
   - Fire OS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/x-sign.yaml
+++ b/data/products/x-sign.yaml
@@ -16,12 +16,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/xibo.yaml
+++ b/data/products/xibo.yaml
@@ -22,9 +22,30 @@ platforms:
   - Tizen
   - webOS
   - Windows
+stats:
+  screens:
+    total: 306000
+    source: https://xibosignage.com/
+    date: 2025-04
+notes:
+  - >-
+    Android, Tizen and webOS players are closed-source, commercial products and require a (perpetual) license if used
+    with a free self-hosted server.
+  - The Tizen player is currently limited to HD resolution on 4K screens.
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: true
+  - free_trial: true
     pricing_available: true
     has_freemium: false
     pricing:
@@ -38,19 +59,3 @@ models:
         billing_basis: per_device
         monthly: 4.9
         yearly: 58.8
-stats:
-  screens:
-    total: 306000
-    source: https://xibosignage.com/
-    date: 2025-04
-notes:
-  - Android, Tizen and webOS players are closed-source, commercial products and require a (perpetual) license if used with a free self-hosted server.
-  - The Tizen player is currently limited to HD resolution on 4K screens.
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/xignage.yaml
+++ b/data/products/xignage.yaml
@@ -17,12 +17,6 @@ platforms:
   - Windows
   - iOS
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -33,3 +27,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/xiphias.yaml
+++ b/data/products/xiphias.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 25000
@@ -31,3 +25,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/xogo.yaml
+++ b/data/products/xogo.yaml
@@ -18,9 +18,22 @@ platforms:
   - iOS
   - Web Browser
   - Windows
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
 models:
-  - delivery: cloud
-    free_trial: false
+  - free_trial: false
     pricing_available: true
     has_freemium: true
     pricing:
@@ -34,13 +47,3 @@ models:
         billing_basis: per_device
         monthly: 20
         yearly: 180
-stats: {}
-notes: []
-features: []
-integrations: []
-target_audience: []
-deployment_options: []
-support_channels: []
-languages: []
-screenshots: []
-last_verified: null

--- a/data/products/xopvision.yaml
+++ b/data/products/xopvision.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/xtravu.yaml
+++ b/data/products/xtravu.yaml
@@ -14,12 +14,6 @@ platforms:
   - Linux
   - Windows
   - macOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/xtremesignage.yaml
+++ b/data/products/xtremesignage.yaml
@@ -14,12 +14,6 @@ platforms:
   - Android
   - Fire OS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 25000
@@ -34,3 +28,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/xuniplay.yaml
+++ b/data/products/xuniplay.yaml
@@ -16,12 +16,6 @@ platforms:
   - Raspberry Pi
   - Tizen
   - Windows
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -32,3 +26,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/yap-create.yaml
+++ b/data/products/yap-create.yaml
@@ -11,12 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -27,3 +21,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/ycd-ramp.yaml
+++ b/data/products/ycd-ramp.yaml
@@ -18,12 +18,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 120000
@@ -38,3 +32,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/yodeck.yaml
+++ b/data/products/yodeck.yaml
@@ -22,22 +22,6 @@ platforms:
   - Web Browser
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: true
-    pricing:
-      - name: Single Screen Account
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 0
-        yearly: 0
-      - name: Basic
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 8
-        yearly: null
 stats:
   screens:
     total: 180000
@@ -52,3 +36,22 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Single Screen Account
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 0
+        yearly: 0
+      - name: Basic
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 8
+        yearly: null

--- a/data/products/yugna.yaml
+++ b/data/products/yugna.yaml
@@ -15,17 +15,6 @@ platforms:
   - Android
   - Fire OS
   - Web Browser
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Standard
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 4
-        yearly: 40
 stats: {}
 notes: []
 features: []
@@ -37,3 +26,17 @@ languages: []
 screenshots: []
 last_verified: null
 has_sso: true
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Standard
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 4
+        yearly: 40

--- a/data/products/zebrix.yaml
+++ b/data/products/zebrix.yaml
@@ -17,12 +17,6 @@ platforms:
   - Tizen
   - Windows
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats:
   screens:
     total: 50000
@@ -37,3 +31,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/zeetaminds.yaml
+++ b/data/products/zeetaminds.yaml
@@ -17,17 +17,6 @@ platforms:
   - Fire OS
   - webOS
   - Windows
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Business
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 10
-        yearly: 100
 stats:
   screens:
     total: 30000
@@ -42,3 +31,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Business
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 10
+        yearly: 100

--- a/data/products/zeroframe.yaml
+++ b/data/products/zeroframe.yaml
@@ -11,17 +11,6 @@ discontinued: false
 categories:
   - CMS
 platforms: []
-models:
-  - delivery: cloud
-    free_trial: true
-    pricing_available: true
-    has_freemium: false
-    pricing:
-      - name: Collector
-        payment_model: subscription
-        billing_basis: per_device
-        monthly: 9
-        yearly: null
 stats: {}
 notes: []
 features: []
@@ -32,3 +21,17 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: true
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Collector
+        payment_model: subscription
+        billing_basis: per_device
+        monthly: 9
+        yearly: null

--- a/data/products/zignage-zcast.yaml
+++ b/data/products/zignage-zcast.yaml
@@ -14,12 +14,6 @@ categories:
 platforms:
   - BrightSign
   - webOS
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -30,3 +24,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/data/products/zynchro.yaml
+++ b/data/products/zynchro.yaml
@@ -13,12 +13,6 @@ categories:
 platforms:
   - BrightSign
   - Tizen
-models:
-  - delivery: cloud
-    free_trial: false
-    pricing_available: false
-    has_freemium: false
-    pricing: []
 stats: {}
 notes: []
 features: []
@@ -29,3 +23,12 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+deployments:
+  cloud: true
+  on_premise: null
+  self_hosted: null
+models:
+  - free_trial: false
+    pricing_available: false
+    has_freemium: false
+    pricing: []

--- a/layouts/partials/pricing-sort-value.html
+++ b/layouts/partials/pricing-sort-value.html
@@ -6,10 +6,8 @@
 {{ $value := 999999.0 }}
 {{ $cloudModel := false }}
 
-{{ range .Params.models }}
-  {{ if eq .delivery "cloud" }}
-    {{ $cloudModel = . }}
-  {{ end }}
+{{ if .Params.models }}
+  {{ $cloudModel = index .Params.models 0 }}
 {{ end }}
 
 {{ if and $cloudModel $cloudModel.pricing_available }}

--- a/layouts/partials/product-pricing.html
+++ b/layouts/partials/product-pricing.html
@@ -6,10 +6,8 @@
 {{ $result := "-" }}
 {{ $cloudModel := false }}
 
-{{ range .Params.models }}
-  {{ if eq .delivery "cloud" }}
-    {{ $cloudModel = . }}
-  {{ end }}
+{{ if .Params.models }}
+  {{ $cloudModel = index .Params.models 0 }}
 {{ end }}
 
 {{ if and .Params.open_source (not (and $cloudModel $cloudModel.pricing_available)) }}

--- a/layouts/partials/schema/software-app.html
+++ b/layouts/partials/schema/software-app.html
@@ -9,7 +9,7 @@
 	{{ with $p.platforms }}"operatingSystem": "{{ delimit . ", " }}",{{ end }}
 	"url": "{{ .Permalink }}",
 	{{ $cloudModel := false }}
-	{{ range $p.models }}{{ if eq .delivery "cloud" }}{{ $cloudModel = . }}{{ end }}{{ end }}
+	{{ if $p.models }}{{ $cloudModel = index $p.models 0 }}{{ end }}
 	{{ if and $cloudModel $cloudModel.pricing_available }}
 	{{ $firstPricing := false }}
 	{{ range $cloudModel.pricing }}{{ if and (not $firstPricing) .monthly }}{{ $firstPricing = . }}{{ end }}{{ end }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -70,11 +70,6 @@
 						{{ end }}
 					</tbody>
 				</table>
-				{{ with .delivery }}
-				<div class="px-6 py-3 border-t border-neutral-100 bg-neutral-50/50">
-					<p class="text-xs text-neutral-400">Delivery: <span class="capitalize text-neutral-500">{{ . }}</span></p>
-				</div>
-				{{ end }}
 			</div>
 			{{ end }}
 			{{ end }}

--- a/scripts/lib/schema.ts
+++ b/scripts/lib/schema.ts
@@ -2,7 +2,13 @@ import { z } from 'zod'
 
 const ProductCategorySchema = z.enum(['CMS', 'Content provider', 'Computer vision'])
 
-const DeliverySchema = z.enum(['cloud', 'on-premise', 'hybrid', 'self-hosted'])
+const DeploymentSchema = z
+	.object({
+		cloud: z.boolean().nullable().default(null),
+		on_premise: z.boolean().nullable().default(null),
+		self_hosted: z.boolean().nullable().default(null),
+	})
+	.default({ cloud: null, on_premise: null, self_hosted: null })
 
 const PaymentModelSchema = z.enum(['subscription', 'one-time', 'pay-as-you-go', 'free'])
 
@@ -21,7 +27,6 @@ const PricingSchema = z.object({
 })
 
 const ModelSchema = z.object({
-	delivery: DeliverySchema,
 	free_trial: z.boolean(),
 	pricing_available: z.boolean(),
 	has_freemium: z.boolean(),
@@ -71,6 +76,10 @@ const ProductSchema = z
 		has_saml: z.boolean().default(false),
 		self_signup: z.boolean(),
 		discontinued: z.boolean(),
+
+		// Deployment
+		deployments: DeploymentSchema,
+
 		// Taxonomies
 		categories: z.array(ProductCategorySchema),
 		platforms: z.array(z.string()),
@@ -102,9 +111,10 @@ const ProductSchema = z
 		path: ['developer_portal_url'],
 	})
 
-export { ProductSchema, ProductCategorySchema, ModelSchema, PricingSchema }
+export { ProductSchema, ProductCategorySchema, ModelSchema, PricingSchema, DeploymentSchema }
 
 export type Product = z.infer<typeof ProductSchema>
 export type ProductCategory = z.infer<typeof ProductCategorySchema>
 export type Model = z.infer<typeof ModelSchema>
 export type Pricing = z.infer<typeof PricingSchema>
+export type Deployment = z.infer<typeof DeploymentSchema>


### PR DESCRIPTION
Closes #52

Replaces the string `delivery` field on models with a top-level `deployments` object:

```yaml
deployments:
  cloud: true       # true = confirmed, false = confirmed not, null = not explored
  on_premise: null
  self_hosted: null
```

Changes:
- `DeploymentSchema` added to `scripts/lib/schema.ts`, `delivery` enum removed from `ModelSchema`
- All 555 existing products migrated: deployments derived from old delivery values, multi-delivery model arrays collapsed into one