### PR TITLE
docs: add DATA_SOURCES.md

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -1,0 +1,10 @@
+# Data Sources
+
+Partner directories and product catalogues used to discover and verify products listed on SignageList.
+
+- https://www.brightsign.biz/partners/
+- https://signage.amazon.com/cms-partners
+- https://www.sharpdisplays.eu/p/retail/en/partner.xhtml
+- https://www.raspberrypi.com/for-industry/powered-by/product-catalogue/?industry=Digital+signage
+
+Know a good source? Open an issue or PR to add it.


### PR DESCRIPTION
Adds `DATA_SOURCES.md` listing partner directories used to discover and verify products -- BrightSign, Amazon Signage, Sharp Displays, and Raspberry Pi. Also invites contributions of additional sources.

Closes #64