### PR TITLE
Update World VDS

### DIFF
--- a/data/products/worldvds.yaml
+++ b/data/products/worldvds.yaml
@@ -6,14 +6,18 @@ year_founded: 2012
 headquarters:
   - Portugal
 open_source: false
+has_api: true
+developer_portal_url: https://www.amplitudenet.pt/en/digital-signage-software/
+has_sso: true
 self_signup: false
-discontinued: true
+discontinued: false
 categories:
   - CMS
 platforms:
   - Android
   - Fire OS
   - Linux
+  - Raspberry Pi
   - Tizen
   - Windows
   - webOS


### PR DESCRIPTION
Corrects the World VDS entry based on the submission and the vendor website.

Changes:

- discontinued: true to false (the software is operational)
- has_api: now true (the vendor states it offers an API for full data integration)
- has_sso: now true (the vendor lists Single Sign-On authentication)
- platforms: added Raspberry Pi

Source: https://www.amplitudenet.pt/software-digital-signage/

The schema requires a developer_portal_url when has_api is true. There is no dedicated developer portal, so it points to the software page where the API capability is documented. Validated with bun run check (571 valid, 0 invalid).

Closes #148