### PR TITLE
data: remove note from Digital Signage Apps

### DIFF
--- a/data/products/digital-signage-apps.yaml
+++ b/data/products/digital-signage-apps.yaml
@@ -25,8 +25,7 @@ models:
         monthly: 0
         yearly: null
 stats: {}
-notes:
-  - Free and open-source apps maintained under the Screenly-Labs organization; usable on any screen and self-hostable.
+notes: []
 features: []
 integrations: []
 target_audience: []


### PR DESCRIPTION
Removes the notes entry from the Digital Signage Apps product as requested. Sets notes to an empty list.

Validated with bun run check.