### PR TITLE
data: add FloSync product (#167)

### DIFF
--- a/data/products/flosync.yaml
+++ b/data/products/flosync.yaml
@@ -1,0 +1,38 @@
+name: FloSync
+slug: flosync
+description: Free software for digital signage and video walls, running synchronized video, image, and web content across one or many computers.
+website: https://flosync.com
+year_founded: 2007
+headquarters:
+  - USA
+open_source: false
+has_docs: true
+docs_url: https://flosync.com/docs/
+self_signup: true
+discontinued: false
+categories:
+  - CMS
+platforms:
+  - Windows
+  - macOS
+models:
+  - delivery: on-premise
+    free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: Free
+        payment_model: free
+        billing_basis: flat_rate
+        monthly: 0
+        yearly: 0
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null


### PR DESCRIPTION
Adds FloSync as a CMS, closes #167.

FloSync is free software for digital signage and video walls, running synchronized video, image, and web content across one or many computers on macOS and Windows.

## Details
- **Category:** CMS
- **Headquarters:** USA (Chicago, Illinois)
- **Year founded:** 2007
- **Platforms:** Windows, macOS
- **Open source:** No
- **Self-signup:** Yes (free download, no signup required)
- **Pricing:** Free (no monthly fees; currently v0.5.0)
- **Delivery:** On-premise (downloadable desktop app)
- **Docs:** https://flosync.com/docs/ (added beyond the issue's fields)

Validated with `bun run check` (578/578 valid) and confirmed the product page builds with Hugo.