### PR TITLE
data: add AppCarousel product (#169, #176)

### DIFF
--- a/data/products/appcarousel.yaml
+++ b/data/products/appcarousel.yaml
@@ -1,0 +1,39 @@
+name: AppCarousel
+slug: appcarousel
+description: Android app that turns old phones and tablets into always-on smart displays, cycling through photos, web pages, and apps with no new hardware needed.
+website: https://360wonder.co.uk
+year_founded: 2026
+headquarters:
+  - United Kingdom
+open_source: false
+has_docs: false
+docs_url: null
+self_signup: true
+discontinued: false
+categories:
+  - CMS
+platforms:
+  - Android
+  - Fire OS
+models:
+  - delivery: self-hosted
+    free_trial: false
+    pricing_available: true
+    has_freemium: false
+    pricing:
+      - name: One-time purchase
+        payment_model: one-time
+        billing_basis: flat_rate
+        monthly: null
+        yearly: null
+        price: 3.49
+stats: {}
+notes: []
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null


### PR DESCRIPTION
Adds AppCarousel by 360Wonder as a CMS. Closes #169 and #176 (same product, submitted twice by the same author).

AppCarousel is an Android app that turns old phones and tablets into always-on smart displays, cycling through photos, web pages, and apps — no new hardware needed.

## Details
- **Category:** CMS
- **Headquarters:** United Kingdom
- **Year founded:** 2026 (product launched 2026; brand founded 2023)
- **Platforms:** Android (+ Fire OS per the repo's Android↔Fire OS symmetry convention)
- **Open source:** No
- **Self-signup:** Yes (install from Google Play, no registration)
- **Pricing:** One-time purchase, $3.49 (USD) on Google Play
- **Delivery:** Self-hosted (runs entirely on the user's own Android device)

Verified against the [Google Play listing](https://play.google.com/store/apps/details?id=uk.co.threesixtywonder.carouselapp) and [360wonder.co.uk](https://360wonder.co.uk). `bun run check` passes (578/578) and Hugo builds the page.