### PR TITLE
content: add 2026-07-23 release notes

### DIFF
--- a/content/updates/2026-07-23.md
+++ b/content/updates/2026-07-23.md
@@ -1,0 +1,15 @@
+---
+title: "Two new products: AppCarousel and FloSync"
+date: 2026-07-23
+description: "Added two new products to the directory."
+products:
+  - slug: appcarousel
+    change: "New listing: an Android app that turns old phones and tablets into always-on smart displays. One-time $3.49 purchase on Google Play."
+  - slug: flosync
+    change: "New listing: free digital signage and video wall software for macOS and Windows, with synchronized playback across multiple screens."
+---
+
+Two products joined the directory, both suggested by the community:
+
+- **AppCarousel** by 360Wonder, a self-hosted Android smart display app focused on repurposing old devices.
+- **FloSync**, free software for digital signage and video walls on macOS and Windows.


### PR DESCRIPTION
Adds a `/updates` changelog entry for today covering the two products added and merged today:

- **AppCarousel** (#169, #176) — Android smart display app by 360Wonder
- **FloSync** (#167) — free digital signage & video wall software for macOS/Windows

Both slugs resolve to their product pages, so the entry renders with logos and links. `hugo --minify` builds cleanly.