### PR TITLE
data: add documentation links for first 25 sales-led products

### DIFF
--- a/data/products/22miles.yaml
+++ b/data/products/22miles.yaml
@@ -6,6 +6,8 @@ year_founded: 2007
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://wiki.22miles.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/42-digital-signage.yaml
+++ b/data/products/42-digital-signage.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.42digitalsignage.com/digital-signage-cms/feed/
+has_docs: true
+docs_url: https://app.42digitalsignage.com/help
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/4dcast.yaml
+++ b/data/products/4dcast.yaml
@@ -6,6 +6,8 @@ year_founded: 2016
 headquarters:
   - Germany
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/abuzz.yaml
+++ b/data/products/abuzz.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Australia
 open_source: false
 rss_feed_url: https://www.abuzzsolutions.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/acquire2go.yaml
+++ b/data/products/acquire2go.yaml
@@ -6,6 +6,8 @@ year_founded: 2008
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: true
+docs_url: https://knowledge.acquiredigital.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/acrelec.yaml
+++ b/data/products/acrelec.yaml
@@ -7,6 +7,8 @@ headquarters:
   - France
 open_source: false
 rss_feed_url: https://acrelec.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/acumen-cms.yaml
+++ b/data/products/acumen-cms.yaml
@@ -7,6 +7,8 @@ headquarters:
   - India
 open_source: false
 rss_feed_url: https://acumencms.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ad-sign.yaml
+++ b/data/products/ad-sign.yaml
@@ -6,6 +6,8 @@ year_founded: 2022
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: true
+docs_url: https://ad-sign.tv/docs/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/adfloow.yaml
+++ b/data/products/adfloow.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Sweden
 open_source: false
 rss_feed_url: https://adfloow.com/rss.xml
+has_docs: true
+docs_url: https://adfloow.com/support/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/admaster.yaml
+++ b/data/products/admaster.yaml
@@ -6,6 +6,8 @@ year_founded: 2014
 headquarters:
   - Russia
 open_source: false
+has_docs: true
+docs_url: https://admaster.io/docs/guide.pdf
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/admobilize.yaml
+++ b/data/products/admobilize.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters: []
 open_source: false
 rss_feed_url: https://admobilize.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/adooh.yaml
+++ b/data/products/adooh.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Singapore
 open_source: false
 rss_feed_url: https://www.adooh.io/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/adscreen.yaml
+++ b/data/products/adscreen.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - Poland
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/adv-signage.yaml
+++ b/data/products/adv-signage.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Italy
 open_source: false
 rss_feed_url: https://advsignage.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/advertima.yaml
+++ b/data/products/advertima.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters: []
 open_source: false
 rss_feed_url: https://advertima.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/aem-screens.yaml
+++ b/data/products/aem-screens.yaml
@@ -6,6 +6,8 @@ year_founded: 2016
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://experienceleague.adobe.com/en/docs/experience-manager-screens/user-guide/aem-screens-introduction
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/airtame.yaml
+++ b/data/products/airtame.yaml
@@ -6,6 +6,8 @@ year_founded: 2013
 headquarters:
   - Denmark
 open_source: false
+has_docs: true
+docs_url: https://help.airtame.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/aitrios.yaml
+++ b/data/products/aitrios.yaml
@@ -5,6 +5,8 @@ website: https://www.aitrios.sony-semicon.com/
 year_founded: null
 headquarters: []
 open_source: false
+has_docs: true
+docs_url: https://developer.aitrios.sony-semicon.com/en/docs
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/alpha-digital.yaml
+++ b/data/products/alpha-digital.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Thailand
 open_source: false
 rss_feed_url: https://alphadigital.co/products/digital-signage-software/rss.xml
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/alto.yaml
+++ b/data/products/alto.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.netsync.com/solutions/alto/alto-digital-signage/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/anthias.yaml
+++ b/data/products/anthias.yaml
@@ -8,6 +8,8 @@ headquarters:
 open_source: true
 license: GPL-2.0-only
 source_code_url: https://github.com/Screenly/Anthias
+has_docs: true
+docs_url: https://anthias.screenly.io/docs/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/appsuite.yaml
+++ b/data/products/appsuite.yaml
@@ -6,6 +6,8 @@ year_founded: 2009
 headquarters:
   - Germany
 open_source: false
+has_docs: true
+docs_url: https://www.mediaroom.eyefactive.com/technical-info/AppSuite-Documentation-EN.pdf
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/aquaji.yaml
+++ b/data/products/aquaji.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters: []
 open_source: false
 rss_feed_url: https://aquaji.com/feed/
+has_docs: true
+docs_url: https://manual-aquajipro.navori.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/arreya.yaml
+++ b/data/products/arreya.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://arreya.com/feed/
+has_docs: true
+docs_url: https://support.arreya.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/atmospheretv.yaml
+++ b/data/products/atmospheretv.yaml
@@ -6,6 +6,8 @@ year_founded: 2019
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://help.atmosphere.tv/
 self_signup: false
 discontinued: false
 categories:


### PR DESCRIPTION
Starts extending the documentation rollout to non-self-signup (sales-led) products — the self-signup tier was completed earlier (#173, #174).

This is the first batch: the first 25 sales-led products (alphabetical). Each was researched and every documentation URL was actually opened and confirmed to be genuine documentation, not guessed.

## Bar for `has_docs: true`
A real, multi-page documentation resource: knowledge base, user manual/guide, or docs portal. A standalone marketing **FAQ page does not count**, nor do contact-only support pages, login-gated portals, or videos-only pages.

## Results (14 with docs, 11 without)

**Documentation found:**
- 22Miles — https://wiki.22miles.com/
- 42 Digital Signage — https://app.42digitalsignage.com/help
- Acquire2Go — https://knowledge.acquiredigital.com/
- AD+Sign — https://ad-sign.tv/docs/
- AdFloow — https://adfloow.com/support/
- ADMASTER — https://admaster.io/docs/guide.pdf (32-page manual)
- Experience Manager Screens — https://experienceleague.adobe.com/en/docs/experience-manager-screens/user-guide/aem-screens-introduction
- Airtame — https://help.airtame.com/hc/en-us
- AITRIOS — https://developer.aitrios.sony-semicon.com/en/docs
- Anthias — https://anthias.screenly.io/docs/
- AppSuite — https://www.mediaroom.eyefactive.com/technical-info/AppSuite-Documentation-EN.pdf (58-page manual)
- Aquaji — https://manual-aquajipro.navori.com/
- Arreya — https://support.arreya.com/
- AtmosphereTV — https://help.atmosphere.tv/

**No public docs** (marketing/FAQ/contact-only or login-gated): 4Dcast, Abuzz, Acrelec, Acumen CMS, AdMobilize, Adooh, ADScreen, ADV Signage, Advertima, Alpha Digital, ALTO.

`bun run check` passes (579/579) and Hugo builds cleanly with the new sidebar docs links.