### PR TITLE
data: add documentation links for next 50 sales-led products (26-75)

### DIFF
--- a/data/products/audience-cms.yaml
+++ b/data/products/audience-cms.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Canada
 open_source: false
 rss_feed_url: https://www.capitalnetworks.com/audience-cms/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/autora-dsm.yaml
+++ b/data/products/autora-dsm.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://go.autoradsm.com/help
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/avesign.yaml
+++ b/data/products/avesign.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - Russia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/aware.yaml
+++ b/data/products/aware.yaml
@@ -6,6 +6,8 @@ year_founded: 1998
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/axistv.yaml
+++ b/data/products/axistv.yaml
@@ -6,6 +6,8 @@ year_founded: 2000
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://help.visix.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/beeceen.yaml
+++ b/data/products/beeceen.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Germany
 open_source: false
 rss_feed_url: https://www.xplace-group.com/en/products/beeceen/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/blynk.yaml
+++ b/data/products/blynk.yaml
@@ -7,6 +7,8 @@ headquarters:
   - United Kingdom
 open_source: false
 rss_feed_url: https://blynk.co.uk/content-programming/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/brandtv.yaml
+++ b/data/products/brandtv.yaml
@@ -6,6 +6,8 @@ year_founded: 2019
 headquarters:
   - Poland
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/brandvisionhd.yaml
+++ b/data/products/brandvisionhd.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.pwcampbell.com/brandvisionhd/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/breeze.yaml
+++ b/data/products/breeze.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://keywesttechnology.com/breeze-digital-signage/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/broadsign.yaml
+++ b/data/products/broadsign.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Canada
 open_source: false
 rss_feed_url: https://broadsign.com/rss.xml
+has_docs: true
+docs_url: https://docs.broadsign.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/budsense.yaml
+++ b/data/products/budsense.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.mybudsense.com/blog/rss.xml
+has_docs: true
+docs_url: https://support.mybudsense.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/buetema.yaml
+++ b/data/products/buetema.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - Germany
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/butikstv.yaml
+++ b/data/products/butikstv.yaml
@@ -6,6 +6,8 @@ year_founded: 2012
 headquarters:
   - Sweden
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/canvaspro.yaml
+++ b/data/products/canvaspro.yaml
@@ -5,6 +5,8 @@ website: https://canvaspro.tech/
 year_founded: 2024
 headquarters: []
 open_source: false
+has_docs: true
+docs_url: https://docs.canvaspro.tech/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/carousel.yaml
+++ b/data/products/carousel.yaml
@@ -10,6 +10,8 @@ has_api: true
 developer_portal_url: https://www.carouselsignage.com/cloud/api
 has_sso: true
 has_saml: true
+has_docs: true
+docs_url: https://support.carouselsignage.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cayin.yaml
+++ b/data/products/cayin.yaml
@@ -6,6 +6,8 @@ year_founded: 2004
 headquarters:
   - Taiwan
 open_source: false
+has_docs: true
+docs_url: https://onlinehelp.cayintech.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cenareo.yaml
+++ b/data/products/cenareo.yaml
@@ -6,6 +6,8 @@ year_founded: 2012
 headquarters:
   - France
 open_source: false
+has_docs: true
+docs_url: https://help.cenareo.com/kb/en/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/centoview.yaml
+++ b/data/products/centoview.yaml
@@ -6,6 +6,8 @@ year_founded: 2006
 headquarters:
   - Belgium
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/chrome-sign-builder.yaml
+++ b/data/products/chrome-sign-builder.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - Ireland
 open_source: false
+has_docs: true
+docs_url: https://support.google.com/chrome/a/answer/6180529
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/clarity.yaml
+++ b/data/products/clarity.yaml
@@ -6,6 +6,8 @@ year_founded: 2001
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/clearconnect.yaml
+++ b/data/products/clearconnect.yaml
@@ -6,6 +6,8 @@ year_founded: 2019
 headquarters:
   - Japan
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cleverlive.yaml
+++ b/data/products/cleverlive.yaml
@@ -6,6 +6,8 @@ year_founded: 2021
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: true
+docs_url: https://support.clevertouch.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cleverq-picturemachine.yaml
+++ b/data/products/cleverq-picturemachine.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - Germany
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/clicandpublish.yaml
+++ b/data/products/clicandpublish.yaml
@@ -7,6 +7,8 @@ headquarters:
   - New Caledonia
 open_source: false
 rss_feed_url: https://visualcom.nc/affichage-dynamique/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cloudexa.yaml
+++ b/data/products/cloudexa.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Japan
 open_source: false
 rss_feed_url: https://www.cloudpoint.co.jp/digitalsignage/cloudexa/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/coatro.yaml
+++ b/data/products/coatro.yaml
@@ -5,6 +5,8 @@ website: https://www.meldcx.com/products/coatro
 year_founded: null
 headquarters: []
 open_source: false
+has_docs: true
+docs_url: https://meldcx.zendesk.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/concerto.yaml
+++ b/data/products/concerto.yaml
@@ -8,6 +8,8 @@ headquarters:
 open_source: true
 license: Apache-2.0
 source_code_url: https://github.com/concerto/concerto
+has_docs: true
+docs_url: https://github.com/concerto/concerto/wiki
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/connectedsign.yaml
+++ b/data/products/connectedsign.yaml
@@ -6,6 +6,8 @@ year_founded: 2005
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/control-play.yaml
+++ b/data/products/control-play.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Canada
 open_source: false
 rss_feed_url: https://www.controlplay.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/coolerx.yaml
+++ b/data/products/coolerx.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/corevo.yaml
+++ b/data/products/corevo.yaml
@@ -6,6 +6,8 @@ year_founded: 2011
 headquarters:
   - Netherlands
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cortex.yaml
+++ b/data/products/cortex.yaml
@@ -6,6 +6,8 @@ year_founded: 2011
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://help.vistarmedia.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/crowntv.yaml
+++ b/data/products/crowntv.yaml
@@ -6,6 +6,8 @@ year_founded: 2014
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://www.crowntv-us.com/help/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cs-play.yaml
+++ b/data/products/cs-play.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Russia
   - Singapore
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cubic-media.yaml
+++ b/data/products/cubic-media.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Russia
 open_source: false
 rss_feed_url: https://ds.cubicmedia.ru/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cyberlink-faceme.yaml
+++ b/data/products/cyberlink-faceme.yaml
@@ -5,6 +5,8 @@ website: https://www.cyberlink.com/faceme
 year_founded: null
 headquarters: []
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/d-i-s-play.yaml
+++ b/data/products/d-i-s-play.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Greece
 open_source: false
 rss_feed_url: https://www.playinstore.gr/en/software/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/datavisiooh.yaml
+++ b/data/products/datavisiooh.yaml
@@ -5,6 +5,8 @@ website: https://www.datavisiooh.com/
 year_founded: null
 headquarters: []
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/dcmcloud.yaml
+++ b/data/products/dcmcloud.yaml
@@ -6,6 +6,8 @@ year_founded: 2008
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://www.dcmediads.com/support/downloads/usermanual.pdf
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/deepiscreen.yaml
+++ b/data/products/deepiscreen.yaml
@@ -7,6 +7,8 @@ headquarters:
   - France
 open_source: false
 rss_feed_url: https://deepidoo.com/en/our-solutions/deepiscreen/feed/
+has_docs: true
+docs_url: https://deepischool.zendesk.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/denevads.yaml
+++ b/data/products/denevads.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Spain
 open_source: false
 rss_feed_url: https://www.denevads.es/en/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/digimago.yaml
+++ b/data/products/digimago.yaml
@@ -6,6 +6,8 @@ year_founded: 2009
 headquarters:
   - Germany
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/digiongo.yaml
+++ b/data/products/digiongo.yaml
@@ -6,6 +6,8 @@ year_founded: 2025
 headquarters: ["Serbia"]
 open_source: false
 rss_feed_url: null
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories: ["CMS"]

--- a/data/products/digisign-play.yaml
+++ b/data/products/digisign-play.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - Indonesia
 open_source: false
+has_docs: true
+docs_url: https://digisignplay.com/manuals-guide
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/dise.yaml
+++ b/data/products/dise.yaml
@@ -7,6 +7,9 @@ headquarters:
   - Sweden
 open_source: false
 rss_feed_url: https://www.dise.com/feed/
+# Knowledge base at kb8.dise.com could not be accessed (connection refused); docs status unverified
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/displai.yaml
+++ b/data/products/displai.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://help.displai.ai/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/display-star.yaml
+++ b/data/products/display-star.yaml
@@ -6,6 +6,8 @@ year_founded: 2005
 headquarters:
   - Germany
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/displayhub.yaml
+++ b/data/products/displayhub.yaml
@@ -7,6 +7,8 @@ headquarters:
   - United Kingdom
 open_source: false
 rss_feed_url: https://displayhub.co.uk/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/displaymonkey.yaml
+++ b/data/products/displaymonkey.yaml
@@ -8,6 +8,8 @@ headquarters:
 open_source: true
 license: MIT
 source_code_url: https://github.com/fuel9/DisplayMonkey
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: true
 categories:


### PR DESCRIPTION
Second batch of the sales-led documentation rollout (continues #181). Products 26–75 alphabetically.

Every documentation URL was actually opened and confirmed to be genuine documentation, not guessed. A standalone marketing FAQ page does not count, nor do contact-only support pages, login-gated portals, or videos/course-only platforms.

## Results (18 with docs, 32 without)

**Documentation found (18):**
- Autora DSM — https://go.autoradsm.com/help
- AxisTV (Visix) — https://help.visix.com/
- Broadsign — https://docs.broadsign.com/
- BudSense — https://support.mybudsense.com/
- CanvasPro — https://docs.canvaspro.tech/
- Carousel — https://support.carouselsignage.com/hc/en-us
- CAYIN — https://onlinehelp.cayintech.com/
- Cenareo — https://help.cenareo.com/kb/en/
- Chrome Sign Builder — https://support.google.com/chrome/a/answer/6180529
- CleverLive (Clevertouch) — https://support.clevertouch.com/
- COATRO (meldCX) — https://meldcx.zendesk.com/hc/en-us
- Concerto — https://github.com/concerto/concerto/wiki
- Cortex (Vistar) — https://help.vistarmedia.com/hc/en-us
- CrownTV — https://www.crowntv-us.com/help/
- DC Media Cloud — https://www.dcmediads.com/support/downloads/usermanual.pdf
- Deepiscreen (Deepidoo) — https://deepischool.zendesk.com/hc/en-us
- Digisign Play — https://digisignplay.com/manuals-guide
- Displai — https://help.displai.ai/

**No qualifying public docs (32):** Audience CMS, Avesign, Aware, BEECEEN, Blynk, Brand TV, BrandVisionHD, Breeze, Bütema, ButiksTV, Centoview, Creative Realities Clarity, ClearConnect, cleverQ Picturemachine, ClicAndPublish, CloudExa, ConnectedSign, Control Play, CoolerX, Corevo, CS Play, Кубик Медиа, FaceMe, D.I.S.Play, Datavisiooh, DenevaDS, digimago, DigiOnGo, Dise, Display Star, DisplayHub, DisplayMonkey.

## Notes
- **Cloudflare/403-blocked sites verified via browser:** Carousel, CleverLive, COATRO, Cortex, Deepiscreen — all confirmed real docs (their help centers block automated fetches but load normally).
- **Corrections:** Autora DSM (public KB, not login-gated), COATRO, Cortex, Deepiscreen were initially flagged unverifiable, then confirmed.
- **Dise** — its knowledge base (`kb8.dise.com`) refused all connections and could not be verified; marked `false` with an inline comment recording that the site was unreachable.
- **Breeze** — only a third-party ManualsLib manual (no first-party docs), so marked `false`.

`bun run check` passes (579/579) and Hugo builds cleanly with the new sidebar docs links.