### PR TITLE
data: add documentation links for next 100 sales-led products (76-175)

### DIFF
--- a/data/products/donatello-suite.yaml
+++ b/data/products/donatello-suite.yaml
@@ -7,6 +7,8 @@ headquarters:
   - UAE
 open_source: false
 rss_feed_url: https://www.wavetec.com/solutions/digital-signage/software/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/doohclick.yaml
+++ b/data/products/doohclick.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Sweden
 open_source: false
 rss_feed_url: https://doohclick.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/doohlabs-in-store-impact.yaml
+++ b/data/products/doohlabs-in-store-impact.yaml
@@ -6,6 +6,8 @@ year_founded: 2018
 headquarters:
   - Finland
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/doohly.yaml
+++ b/data/products/doohly.yaml
@@ -6,6 +6,8 @@ year_founded: 2020
 headquarters:
   - Australia
 open_source: false
+has_docs: true
+docs_url: https://help.dooh.ly/docs
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/doohmain.yaml
+++ b/data/products/doohmain.yaml
@@ -6,6 +6,8 @@ year_founded: 2019
 headquarters:
   - Uruguay
 open_source: false
+has_docs: true
+docs_url: https://doohmain.com/doohmain-academy
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/door-tablet-signs.yaml
+++ b/data/products/door-tablet-signs.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: true
+docs_url: https://www.door-tablet.com/doors-help/get-started
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/download-player.yaml
+++ b/data/products/download-player.yaml
@@ -6,6 +6,8 @@ year_founded: 2008
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://www.downloadplayer.net/help/android/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ds-suit.yaml
+++ b/data/products/ds-suit.yaml
@@ -6,6 +6,8 @@ year_founded: 1999
 headquarters:
   - Turkey
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ds-templates.yaml
+++ b/data/products/ds-templates.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Netherlands
 open_source: false
 rss_feed_url: https://www.digitalsignage-templates.com/software/feed/
+has_docs: true
+docs_url: https://docs.digitalsignage-templates.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/dsplay.yaml
+++ b/data/products/dsplay.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - Greece
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/dsshow.yaml
+++ b/data/products/dsshow.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Germany
 open_source: false
 rss_feed_url: https://www.dsshow.de/feed/
+has_docs: true
+docs_url: https://www.dsshow.de/wp-content/uploads/2025/09/dsshow_manual_de.pdf
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/easescreen.yaml
+++ b/data/products/easescreen.yaml
@@ -6,6 +6,8 @@ year_founded: 1999
 headquarters:
   - Austria
 open_source: false
+has_docs: true
+docs_url: https://support.easescreen.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/easy-multi-display.yaml
+++ b/data/products/easy-multi-display.yaml
@@ -7,6 +7,8 @@ headquarters:
   - France
 open_source: false
 rss_feed_url: https://easymultidisplay.com/feed/
+has_docs: true
+docs_url: https://easymultidisplay.com/support-knowledge-base
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/easycms.yaml
+++ b/data/products/easycms.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Poland
 open_source: false
 rss_feed_url: https://www.myeasycms.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/easyscreen.yaml
+++ b/data/products/easyscreen.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Netherlands
 open_source: false
 rss_feed_url: https://easyscreen.tv/en/digital-signage-software/feed/
+has_docs: true
+docs_url: https://help.cms-ds.com/en
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/eggs-tv.yaml
+++ b/data/products/eggs-tv.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Russia
 open_source: false
 rss_feed_url: https://eggstv.io/rss.xml
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/emagentv.yaml
+++ b/data/products/emagentv.yaml
@@ -6,6 +6,8 @@ year_founded: 2016
 headquarters:
   - India
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/emity.yaml
+++ b/data/products/emity.yaml
@@ -7,6 +7,8 @@ headquarters:
   - France
 open_source: false
 rss_feed_url: https://www.emity.io/en/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/engageiot.yaml
+++ b/data/products/engageiot.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://livewiredigital.com/engage-iot-server/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/engagesuite.yaml
+++ b/data/products/engagesuite.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Sweden
 open_source: false
 rss_feed_url: https://zetadisplay.com/product-and-services/engage-suite/feed/
+has_docs: true
+docs_url: https://zetadisplayengage.kayako.com/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/enplug.yaml
+++ b/data/products/enplug.yaml
@@ -6,6 +6,8 @@ year_founded: 2012
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://support.enplug.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/eumedia-dss.yaml
+++ b/data/products/eumedia-dss.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - Malaysia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/evergreen.yaml
+++ b/data/products/evergreen.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.evergreenhq.com/digital-menu-software/feed/
+has_docs: true
+docs_url: https://evergreen.helpscoutdocs.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/explorestream.yaml
+++ b/data/products/explorestream.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters: ["USA", "Canada"]
 open_source: false
 rss_feed_url: null
+has_docs: true
+docs_url: https://support.explorestream.com/
 self_signup: false
 discontinued: false
 categories: ["CMS"]

--- a/data/products/eye-intelligence.yaml
+++ b/data/products/eye-intelligence.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Canada
   - USA
 open_source: false
+has_docs: true
+docs_url: https://doc.eye-in.com/docs/eye-intelligence-en/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/eyecon.yaml
+++ b/data/products/eyecon.yaml
@@ -6,6 +6,8 @@ year_founded: 2009
 headquarters:
   - China
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ez-ad-tv.yaml
+++ b/data/products/ez-ad-tv.yaml
@@ -6,6 +6,8 @@ year_founded: 2013
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/eze-suite.yaml
+++ b/data/products/eze-suite.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Australia
 open_source: false
 rss_feed_url: https://engagis.com/products-services/eze-suite-platform/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ezposter.yaml
+++ b/data/products/ezposter.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - Australia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/fingermark-supernova.yaml
+++ b/data/products/fingermark-supernova.yaml
@@ -7,6 +7,8 @@ headquarters:
   - New Zealand
 open_source: false
 rss_feed_url: https://fingermark.ai/blog/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/firmchannel.yaml
+++ b/data/products/firmchannel.yaml
@@ -6,6 +6,8 @@ year_founded: 2005
 headquarters:
   - Canada
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/firstouch.yaml
+++ b/data/products/firstouch.yaml
@@ -7,6 +7,8 @@ headquarters:
   - India
 open_source: false
 rss_feed_url: https://firstouchkiosk.com/signage-software/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/five-faces.yaml
+++ b/data/products/five-faces.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - Australia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/flagship-cms.yaml
+++ b/data/products/flagship-cms.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/flame.yaml
+++ b/data/products/flame.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters: []
 open_source: false
 rss_feed_url: https://flameanalytics.com/en/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/flexitive.yaml
+++ b/data/products/flexitive.yaml
@@ -6,6 +6,8 @@ year_founded: 2013
 headquarters:
   - Canada
 open_source: false
+has_docs: true
+docs_url: https://support.flexitive.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/footfallcam.yaml
+++ b/data/products/footfallcam.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters: []
 open_source: false
 rss_feed_url: https://www.footfallcam.com/en/blog/feed/
+has_docs: true
+docs_url: https://www.footfallcam.com/people-counting/knowledge-base/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/foyer.yaml
+++ b/data/products/foyer.yaml
@@ -9,6 +9,8 @@ open_source: true
 license: GPL-3.0-only
 source_code_url: https://github.com/mennolui/wp-foyer
 rss_feed_url: https://foyer.tv/feed/
+has_docs: true
+docs_url: https://wordpress.org/plugins/foyer/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/friendlyway.yaml
+++ b/data/products/friendlyway.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Germany
 open_source: false
 rss_feed_url: https://www.friendlyway.com/feed/
+has_docs: true
+docs_url: https://docs.friendlyway.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/gobright.yaml
+++ b/data/products/gobright.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Netherlands
 open_source: false
 rss_feed_url: https://gobright.com/products/digital-signage/feed/
+has_docs: true
+docs_url: https://support.gobright.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/gorilla-video-analytics.yaml
+++ b/data/products/gorilla-video-analytics.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters: []
 open_source: false
 rss_feed_url: https://www.gorilla-technology.com/technologies/video-analytics/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/gotiger.yaml
+++ b/data/products/gotiger.yaml
@@ -6,6 +6,8 @@ year_founded: 2009
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/grassfish-ixm-platform.yaml
+++ b/data/products/grassfish-ixm-platform.yaml
@@ -6,6 +6,8 @@ year_founded: 2005
 headquarters:
   - Sweden
 open_source: false
+has_docs: true
+docs_url: https://docs.grassfish.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/greenscreens.yaml
+++ b/data/products/greenscreens.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://greenscreens.tv/feed.xml
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/grubbrr.yaml
+++ b/data/products/grubbrr.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://grubbrr.com/feed/
+has_docs: true
+docs_url: https://help.grubbrr.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/haivision-coolsign.yaml
+++ b/data/products/haivision-coolsign.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - Canada
 open_source: false
+has_docs: true
+docs_url: https://doc.haivision.com/CoolSign
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/halo.yaml
+++ b/data/products/halo.yaml
@@ -6,6 +6,8 @@ year_founded: 2020
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/harmony-digital.yaml
+++ b/data/products/harmony-digital.yaml
@@ -7,6 +7,8 @@ headquarters:
   - United Kingdom
 open_source: false
 rss_feed_url: https://www.harmonydigital.co.uk/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/helloscreens.yaml
+++ b/data/products/helloscreens.yaml
@@ -6,6 +6,8 @@ year_founded: 2021
 headquarters:
   - Poland
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/hexa.yaml
+++ b/data/products/hexa.yaml
@@ -6,6 +6,8 @@ year_founded: 2022
 headquarters:
   - Australia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/hexnode.yaml
+++ b/data/products/hexnode.yaml
@@ -6,6 +6,8 @@ year_founded: 2013
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://www.hexnode.com/mobile-device-management/help/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/hfl-signage-player.yaml
+++ b/data/products/hfl-signage-player.yaml
@@ -8,6 +8,8 @@ headquarters:
 open_source: true
 license: MIT
 source_code_url: https://github.com/henrik-leppa/hfl-signage-player
+has_docs: true
+docs_url: https://github.com/henrik-leppa/hfl-signage-player/blob/master/README.md
 self_signup: false
 discontinued: true
 categories:

--- a/data/products/highview.yaml
+++ b/data/products/highview.yaml
@@ -7,6 +7,8 @@ headquarters:
   - France
 open_source: false
 rss_feed_url: https://madic-digital.fr/solution-highview3/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/hydro-cms.yaml
+++ b/data/products/hydro-cms.yaml
@@ -6,6 +6,8 @@ year_founded: 2008
 headquarters:
   - New Zealand
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/hyper-net.yaml
+++ b/data/products/hyper-net.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - New Zealand
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/hypersign.yaml
+++ b/data/products/hypersign.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://hypersign.com/hypersignplus/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/icompel.yaml
+++ b/data/products/icompel.yaml
@@ -6,6 +6,8 @@ year_founded: 2012
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/idesk.yaml
+++ b/data/products/idesk.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Russia
 open_source: false
 rss_feed_url: https://i-desk.pro/rss.xml
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/idid.yaml
+++ b/data/products/idid.yaml
@@ -6,6 +6,8 @@ year_founded: 2005
 headquarters:
   - Finland
 open_source: false
+has_docs: true
+docs_url: https://tuki.idid.fi/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/idplay.yaml
+++ b/data/products/idplay.yaml
@@ -6,6 +6,8 @@ year_founded: 2016
 headquarters:
   - France
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ievince.yaml
+++ b/data/products/ievince.yaml
@@ -7,6 +7,8 @@ headquarters:
   - India
   - Bahrain
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: true
 categories:

--- a/data/products/iisignage2.yaml
+++ b/data/products/iisignage2.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - Japan
 open_source: false
+has_docs: true
+docs_url: https://cdn.iiyama.com/f/61d111eb173495e55f9889d6ceaa2a6a_cms-user-manual.pdf
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/imidiatv.yaml
+++ b/data/products/imidiatv.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Brazil
 open_source: false
 rss_feed_url: https://pixmidia.com.br/imidiatv/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/immerse.yaml
+++ b/data/products/immerse.yaml
@@ -6,6 +6,8 @@ year_founded: 2004
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/impressbox.yaml
+++ b/data/products/impressbox.yaml
@@ -6,6 +6,8 @@ year_founded: 2013
 headquarters:
   - Lithuania
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/infini-sign.yaml
+++ b/data/products/infini-sign.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters:
   - China
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/infinite-digital-cms.yaml
+++ b/data/products/infinite-digital-cms.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Saudi Arabia
 open_source: false
 rss_feed_url: https://www.famatechnologies.com/infinite-digital-cms/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/infinitys-anima.yaml
+++ b/data/products/infinitys-anima.yaml
@@ -6,6 +6,8 @@ year_founded: 2009
 headquarters:
   - Italy
 open_source: false
+has_docs: true
+docs_url: https://docs.infinitys.it/en/home
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/innes.yaml
+++ b/data/products/innes.yaml
@@ -6,6 +6,9 @@ year_founded: 2005
 headquarters:
   - France
 open_source: false
+# Documentation pages at innes.pro/en/support return 403 (only the FAQ is public); docs status unverified
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: true
 categories:

--- a/data/products/innovative-dmc.yaml
+++ b/data/products/innovative-dmc.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Ukraine
 open_source: false
 rss_feed_url: https://idmc.com.ua/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/intelisa.yaml
+++ b/data/products/intelisa.yaml
@@ -6,6 +6,8 @@ year_founded: 2020
 headquarters:
   - Canada
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/interads.yaml
+++ b/data/products/interads.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters:
   - Indonesia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ipoint.yaml
+++ b/data/products/ipoint.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Belgium
 open_source: false
 rss_feed_url: https://presentationpoint.com/software/ipoint/feed/
+has_docs: true
+docs_url: https://presentationpoint.com/docs/manuals/ip15/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/is-media.yaml
+++ b/data/products/is-media.yaml
@@ -6,6 +6,8 @@ year_founded: 2000
 headquarters:
   - Russia
 open_source: false
+has_docs: true
+docs_url: https://wiki.ccrs.ru/is-media/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/iteq.yaml
+++ b/data/products/iteq.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Serbia
 open_source: false
 rss_feed_url: https://iteq.rs/en/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/itotem.yaml
+++ b/data/products/itotem.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters:
   - Romania
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/jiosignage.yaml
+++ b/data/products/jiosignage.yaml
@@ -6,6 +6,8 @@ year_founded: 2020
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/jiothings-jiosignage.yaml
+++ b/data/products/jiothings-jiosignage.yaml
@@ -6,6 +6,8 @@ year_founded: 2020
 headquarters:
   - India
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/joan.yaml
+++ b/data/products/joan.yaml
@@ -7,6 +7,8 @@ headquarters:
   - United Kingdom
 open_source: false
 rss_feed_url: https://getjoan.com/workplace-digital-signage/feed/
+has_docs: true
+docs_url: https://support.getjoan.com/knowledge
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/kiocast.yaml
+++ b/data/products/kiocast.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - Canada
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/koesio-tv.yaml
+++ b/data/products/koesio-tv.yaml
@@ -6,6 +6,8 @@ year_founded: 2021
 headquarters:
   - France
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/koke.yaml
+++ b/data/products/koke.yaml
@@ -6,6 +6,8 @@ year_founded: 2011
 headquarters:
   - Germany
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/korbyt.yaml
+++ b/data/products/korbyt.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://product.korbyt.com/help
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/l-squared.yaml
+++ b/data/products/l-squared.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://lsquared.com/blog/rss.xml
+has_docs: true
+docs_url: https://help.lsquared.com/knowledge
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/laqorr.yaml
+++ b/data/products/laqorr.yaml
@@ -6,6 +6,8 @@ year_founded: 2016
 headquarters:
   - Australia
 open_source: false
+has_docs: true
+docs_url: https://documentation.laqorr.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ldsk.yaml
+++ b/data/products/ldsk.yaml
@@ -7,6 +7,8 @@ headquarters:
   - United Kingdom
 open_source: false
 rss_feed_url: https://ldsk.io/rss.xml
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/led-display-cms.yaml
+++ b/data/products/led-display-cms.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Canada
 open_source: false
 rss_feed_url: https://www.corumview.com/led-display-cms-platform/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/leftclick.yaml
+++ b/data/products/leftclick.yaml
@@ -6,6 +6,8 @@ year_founded: 2004
 headquarters:
   - Netherlands
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/lg-supersign.yaml
+++ b/data/products/lg-supersign.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - South Korea
 open_source: false
+has_docs: true
+docs_url: https://solutions.lg.com/us/software/supersign/supersign-downloads
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/libre-signage.yaml
+++ b/data/products/libre-signage.yaml
@@ -8,6 +8,8 @@ headquarters:
 open_source: true
 license: BSD-3-Clause
 source_code_url: https://github.com/eerotal/LibreSignage
+has_docs: true
+docs_url: https://github.com/eerotal/LibreSignage
 self_signup: false
 discontinued: true
 categories:

--- a/data/products/lifeloop.yaml
+++ b/data/products/lifeloop.yaml
@@ -6,6 +6,8 @@ year_founded: 2025
 headquarters:
     - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/lira-screen.yaml
+++ b/data/products/lira-screen.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.lirascreen.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/livesignage.yaml
+++ b/data/products/livesignage.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters:
   - Italy
 open_source: false
+has_docs: true
+docs_url: https://help.livesignage.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/livespace.yaml
+++ b/data/products/livespace.yaml
@@ -7,6 +7,8 @@ headquarters:
   - United Kingdom
 open_source: false
 rss_feed_url: https://livespacesignage.co.uk/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/localscreens.yaml
+++ b/data/products/localscreens.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Poland
 open_source: false
 rss_feed_url: https://localscreens.pl/oprogramowanie-digital-signage/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/loop-tv.yaml
+++ b/data/products/loop-tv.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://www.loop.tv/support/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/m-cube.yaml
+++ b/data/products/m-cube.yaml
@@ -6,6 +6,8 @@ year_founded: 2004
 headquarters:
   - Italy
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/m4b-wall.yaml
+++ b/data/products/m4b-wall.yaml
@@ -6,6 +6,8 @@ year_founded: 2004
 headquarters:
   - Poland
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/magic-mirror.yaml
+++ b/data/products/magic-mirror.yaml
@@ -6,6 +6,8 @@ year_founded: 2007
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/magicinfo.yaml
+++ b/data/products/magicinfo.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - South Korea
 open_source: false
+has_docs: true
+docs_url: https://docs.samsungvx.com/
 self_signup: false
 discontinued: false
 categories:


### PR DESCRIPTION
Third batch of the sales-led documentation rollout (continues #181, #182). Products 76–175 alphabetically.

Every documentation URL was actually opened and confirmed to be genuine documentation, not guessed. A standalone marketing FAQ page does not count, nor do contact-only support pages, login-gated portals, or videos/course-only platforms. Third-party-hosted manuals (e.g. ManualsLib) are not treated as first-party docs.

## Results: 38 with docs, 62 without (of 100)

Products with confirmed documentation include: doohly, doohmain, Door Tablet SIGNS, Download Player, DS Templates, DS Show, easescreen, Easy Multi Display, Easyscreen, EngageSuite, Enplug, Evergreen, ExploreStream, Eye-Intelligence, Flexitive, FootfallCam, Foyer, friendlyway, GoBright, Grassfish, GRUBBRR, Haivision CoolSign, hexnode, HFL signage player, iDiD, iiSignage², ANIMA INFINITYS, iPoint, IS-Media, Joan, Korbyt, L Squared, Laqorr, LG SuperSign, Libre Signage, Livesignage, Loop TV, MagicINFO.

## Verification notes
- **Cloudflare/403-blocked help centers verified via browser** (all confirmed real): easescreen, Enplug, GoBright, iiSignage².
- **Corrections made during verification:**
  - GRUBBRR — the Zendesk help center is closed; used the live `help.grubbrr.com` KB instead.
  - iiSignage² — its fetcher was Cloudflare-blocked; found a first-party CMS user manual PDF via browser.
- **INNES** — its documentation pages return 403 (only the FAQ is public); marked `false` with an inline comment.
- **iCOMPEL, Breeze-style third-party manuals** — iCOMPEL only has a ManualsLib-hosted manual (no first-party docs), so marked `false`.

`bun run check` passes (579/579) and Hugo builds cleanly.