### PR TITLE
data: add documentation links for next 50 sales-led products (176-225)

### DIFF
--- a/data/products/magicsign.yaml
+++ b/data/products/magicsign.yaml
@@ -6,6 +6,8 @@ year_founded: 2016
 headquarters:
   - Thailand
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/magit-dsnet.yaml
+++ b/data/products/magit-dsnet.yaml
@@ -6,6 +6,8 @@ year_founded: 2023
 headquarters:
   - Poland
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/marve-ds.yaml
+++ b/data/products/marve-ds.yaml
@@ -6,6 +6,8 @@ year_founded: 2017
 headquarters:
   - Saudi Arabia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/master-signage.yaml
+++ b/data/products/master-signage.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters:
   - India
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mcoms.yaml
+++ b/data/products/mcoms.yaml
@@ -7,6 +7,8 @@ headquarters:
   - United Kingdom
 open_source: false
 rss_feed_url: https://mcoms.com/signage/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/media4display.yaml
+++ b/data/products/media4display.yaml
@@ -6,6 +6,8 @@ year_founded: 2008
 headquarters:
   - France
 open_source: false
+has_docs: true
+docs_url: https://www.telelogos.com/produits/fichiers/Media4Display_QuickStartGuide_EN_600.pdf
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mediacast.yaml
+++ b/data/products/mediacast.yaml
@@ -6,6 +6,8 @@ year_founded: 2002
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mediafusion.yaml
+++ b/data/products/mediafusion.yaml
@@ -6,6 +6,8 @@ year_founded: 2001
 headquarters:
   - Singapore
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mediamanager.yaml
+++ b/data/products/mediamanager.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Poland
 open_source: false
 rss_feed_url: https://applink.pl/en/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mediasignage.yaml
+++ b/data/products/mediasignage.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.hughes.com/what-we-offer/digital-signage/cloud-based-digital-signage-software/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: true
 categories:

--- a/data/products/mediatile.yaml
+++ b/data/products/mediatile.yaml
@@ -6,6 +6,8 @@ year_founded: 2004
 headquarters:
   - Canada
 open_source: false
+has_docs: true
+docs_url: https://mediatile.com/resources/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/medisign.yaml
+++ b/data/products/medisign.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://medisigndisplays.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/menara-ds.yaml
+++ b/data/products/menara-ds.yaml
@@ -6,6 +6,8 @@ year_founded: 2019
 headquarters:
   - Morocco
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/menuzen.yaml
+++ b/data/products/menuzen.yaml
@@ -7,6 +7,9 @@ headquarters:
   - Australia
 open_source: false
 has_sso: true
+# help.menuzen.com could not be accessed (TLS/connection failure); a Freshdesk KB appears to exist but is unverified
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/monitorsanywhere.yaml
+++ b/data/products/monitorsanywhere.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://monitorsanywhere.com/feed/
+has_docs: true
+docs_url: https://help.monitorsanywhere.com/portal/en/kb/monitors-anywhere
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mood-media.yaml
+++ b/data/products/mood-media.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://us.moodmedia.com/sight/digital-signage-software/feed/
+has_docs: true
+docs_url: https://support.moodmedia.com/harmony/welcome-to-harmony/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/moogx.yaml
+++ b/data/products/moogx.yaml
@@ -6,6 +6,8 @@ year_founded: 2012
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/musthavemenus.yaml
+++ b/data/products/musthavemenus.yaml
@@ -6,6 +6,8 @@ year_founded: 2007
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://musthavemenus27.zohodesk.com/portal/en/kb/musthavemenus
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mvix.yaml
+++ b/data/products/mvix.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://mvix.com/blog/rss.xml
+has_docs: true
+docs_url: https://www.mvix.com/knowledgebase
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mysignageportal.yaml
+++ b/data/products/mysignageportal.yaml
@@ -6,6 +6,8 @@ year_founded: 2013
 headquarters:
   - United Kingdom
 open_source: false
+has_docs: true
+docs_url: https://mysignageportal.com/cdms/support/downloads-documents.html
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mysvd.yaml
+++ b/data/products/mysvd.yaml
@@ -6,6 +6,8 @@ year_founded: 2011
 headquarters:
   - France
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/myvideospot.yaml
+++ b/data/products/myvideospot.yaml
@@ -6,6 +6,8 @@ year_founded: 2009
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://docs.myvideospot.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nanonation-commandpoint.yaml
+++ b/data/products/nanonation-commandpoint.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/navigo.yaml
+++ b/data/products/navigo.yaml
@@ -6,6 +6,8 @@ year_founded: 2014
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/navori.yaml
+++ b/data/products/navori.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Switzerland
 open_source: false
 rss_feed_url: https://navori.com/blog/feed/
+has_docs: true
+docs_url: https://kb.navori.com/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nento.yaml
+++ b/data/products/nento.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://nento.com/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/neon.yaml
+++ b/data/products/neon.yaml
@@ -6,6 +6,8 @@ year_founded: 2021
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://support.neonscreens.com/knowledge
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/neoscreen.yaml
+++ b/data/products/neoscreen.yaml
@@ -7,6 +7,8 @@ headquarters:
   - France
 open_source: false
 rss_feed_url: https://affichagedynamique.iagona.com/en/our-software/feed/
+has_docs: true
+docs_url: https://wiki.neoscreen.fr/index.php?title=Accueil
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/neotess.yaml
+++ b/data/products/neotess.yaml
@@ -7,6 +7,8 @@ headquarters:
   - France
 open_source: false
 rss_feed_url: https://www.neotess.fr/logiciel-daffichage-dynamique/feed/
+has_docs: true
+docs_url: https://www.neotess.fr/42783kjkj-hfkdsfd267678/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/netplay.yaml
+++ b/data/products/netplay.yaml
@@ -6,6 +6,8 @@ year_founded: 2003
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://www.video-storm.com/signage.php
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/netpresenter.yaml
+++ b/data/products/netpresenter.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Netherlands
 open_source: false
 rss_feed_url: https://www.netpresenter.com/feed/
+has_docs: true
+docs_url: https://service.netpresenter.com/support
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/netvisual.yaml
+++ b/data/products/netvisual.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Canada
 open_source: false
 rss_feed_url: https://netvisual.ca/digital-signage-solutions/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/newvision.yaml
+++ b/data/products/newvision.yaml
@@ -6,6 +6,8 @@ year_founded: 2000
 headquarters:
   - Portugal
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nonius.yaml
+++ b/data/products/nonius.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Portugal
 open_source: false
 rss_feed_url: https://noniussolutions.com/digital-signage/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/notice-signage.yaml
+++ b/data/products/notice-signage.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Netherlands
 open_source: false
 rss_feed_url: https://www.noticebrandedmedia.com/narrowcasting/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: true
 categories:

--- a/data/products/noventri.yaml
+++ b/data/products/noventri.yaml
@@ -7,6 +7,8 @@ headquarters:
   - USA
 open_source: false
 rss_feed_url: https://www.noventri.com/digital-signage-products/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nsigntv.yaml
+++ b/data/products/nsigntv.yaml
@@ -6,6 +6,8 @@ year_founded: 2007
 headquarters:
   - Spain
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/numia.yaml
+++ b/data/products/numia.yaml
@@ -6,6 +6,8 @@ year_founded: 2024
 headquarters:
   - Argentina
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nusyn.yaml
+++ b/data/products/nusyn.yaml
@@ -6,6 +6,8 @@ year_founded: 2015
 headquarters:
   - India
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nutrislice.yaml
+++ b/data/products/nutrislice.yaml
@@ -6,6 +6,8 @@ year_founded: 2011
 headquarters:
   - USA
 open_source: false
+has_docs: true
+docs_url: https://help.nutrislice.com/hc/en-us
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nuvelar-display.yaml
+++ b/data/products/nuvelar-display.yaml
@@ -6,6 +6,8 @@ year_founded: 2014
 headquarters:
   - Argentina
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/ommasign.yaml
+++ b/data/products/ommasign.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Turkey
 open_source: false
 rss_feed_url: https://ommasign.com/product-software/feed/
+has_docs: true
+docs_url: https://support.ommasign.com/en/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/omnivex.yaml
+++ b/data/products/omnivex.yaml
@@ -6,6 +6,8 @@ year_founded: 1991
 headquarters:
   - Canada
 open_source: false
+has_docs: true
+docs_url: https://www.omnivex.com/support/kb
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/one-ds.yaml
+++ b/data/products/one-ds.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters:
   - South Korea
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/oneblending.yaml
+++ b/data/products/oneblending.yaml
@@ -6,6 +6,8 @@ year_founded: 2010
 headquarters:
   - Russia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/oneview.yaml
+++ b/data/products/oneview.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Serbia
 open_source: false
 rss_feed_url: https://oneview.rs/en/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/onq-cms.yaml
+++ b/data/products/onq-cms.yaml
@@ -6,6 +6,8 @@ year_founded: 2012
 headquarters:
   - Australia
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/opensign.yaml
+++ b/data/products/opensign.yaml
@@ -6,6 +6,8 @@ year_founded: null
 headquarters:
   - USA
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/opensignage.yaml
+++ b/data/products/opensignage.yaml
@@ -6,6 +6,8 @@ year_founded: 2009
 headquarters:
   - Netherlands
 open_source: false
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/oscart.yaml
+++ b/data/products/oscart.yaml
@@ -7,6 +7,8 @@ headquarters:
   - Belgium
 open_source: false
 rss_feed_url: https://www.oscart.eu/cloud-software/feed/
+has_docs: false
+docs_url: null
 self_signup: false
 discontinued: false
 categories:


### PR DESCRIPTION
Fourth batch of the sales-led documentation rollout (continues #181, #182, #183). Products 176–225 alphabetically.

Every documentation URL was actually opened and confirmed to be genuine documentation, not guessed. A standalone marketing FAQ page does not count, nor do contact-only support pages, login-gated portals, videos/course-only platforms, or third-party-only manual hosts (e.g. ManualsLib).

## Results: 17 with docs, 33 without (of 50)

**Documentation found:**
- Media4Display — https://www.telelogos.com/produits/fichiers/Media4Display_QuickStartGuide_EN_600.pdf
- MediaTile — https://mediatile.com/resources/
- Monitors AnyWhere — https://help.monitorsanywhere.com/portal/en/kb/monitors-anywhere
- Mood Harmony — https://support.moodmedia.com/harmony/welcome-to-harmony/
- MustHaveMenus — https://musthavemenus27.zohodesk.com/portal/en/kb/musthavemenus
- Mvix — https://www.mvix.com/knowledgebase
- My Signage Portal — https://mysignageportal.com/cdms/support/downloads-documents.html
- MyVideoSpot — https://docs.myvideospot.com/
- Navori — https://kb.navori.com/
- Neon — https://support.neonscreens.com/knowledge
- Neoscreen — https://wiki.neoscreen.fr/index.php?title=Accueil
- Neotess — https://www.neotess.fr/42783kjkj-hfkdsfd267678/
- NetPlay — https://www.video-storm.com/signage.php
- Netpresenter — https://service.netpresenter.com/support
- Nutrislice — https://help.nutrislice.com/hc/en-us
- OmmaSign — https://support.ommasign.com/en/
- Omnivex — https://www.omnivex.com/support/kb

## Verification notes
- **Nutrislice** help center (Zendesk) blocked automated fetch (403); browser-verified as a real KB with a Digital Signage category.
- **menuzen** — its help center (help.menuzen.com) could not be reached (TLS/connection failure) in fetch or browser; marked `false` with an inline comment (a Freshdesk KB appears to exist but is unverified).
- **Nsigntv** — help center is login-gated (Google OAuth), no public docs → `false`.
- **OpenSign** — the digital-signage product (opensign.us) has no docs; the OpenSign docs/GitHub found in search belong to an unrelated e-signature product.

`bun run check` passes (579/579) and Hugo builds cleanly.