### PR TITLE
data: normalize 'United States' HQ to 'USA'

### DIFF
--- a/data/products/gymboard.yaml
+++ b/data/products/gymboard.yaml
@@ -4,7 +4,7 @@ description: Cloud digital signage CMS for fitness facilities such as BJJ academ
 website: https://gymboard.app
 year_founded: 2026
 headquarters:
-  - United States
+  - USA
 open_source: false
 has_docs: false
 docs_url: null

--- a/data/products/screen-keep.yaml
+++ b/data/products/screen-keep.yaml
@@ -4,7 +4,7 @@ description: Web-powered digital signage app for Android TV, Google TV, and Chro
 website: https://www.screenkeep.com
 year_founded: null
 headquarters:
-  - United States
+  - USA
 open_source: false
 rss_feed_url: https://www.screenkeep.com/rss.xml
 has_docs: false


### PR DESCRIPTION
Normalizes the two products that stored their headquarters as `United States` to `USA`, matching the value used by the other 156 US-based products (the directory otherwise had a `USA` / `United States` split for the same country).

- gymboard
- screen-keep

`bun run check` passes (580/580).