### PR TITLE
fix: remove hardcoded "+" from product count

### DIFF
--- a/content/categories/cms/_index.md
+++ b/content/categories/cms/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "CMS"
 seo_title: "Best Digital Signage CMS Software"
-description: "Browse 500+ digital signage CMS platforms. Compare cloud-based and on-premise content management systems for scheduling, publishing, and managing displays remotely."
+description: "Browse digital signage CMS platforms. Compare cloud-based and on-premise content management systems for scheduling, publishing, and managing displays remotely."
 ---

--- a/content/products/_index.md
+++ b/content/products/_index.md
@@ -1,4 +1,4 @@
 ---
 title: "Digital Signage Software Directory"
-description: "Browse and compare 548+ digital signage software products."
+description: "Browse and compare digital signage software products."
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -9,7 +9,7 @@ capitalizeListTitles = false
   platform = "platforms"
 
 [params]
-  description = "A curated directory of 548+ digital signage software products."
+  description = "A curated directory of digital signage software products."
   githubRepo = "https://github.com/SignageList/signagelist"
 
 # Custom output formats for LLM-friendly pages

--- a/layouts/_default/home.llms.txt
+++ b/layouts/_default/home.llms.txt
@@ -2,7 +2,7 @@
 
 > {{ .Site.Params.description }}
 
-SignageList is a curated open dataset of digital signage software products. It provides structured data on 548+ products including pricing, supported platforms, headquarters, and more.
+SignageList is a curated open dataset of digital signage software products. It provides structured data on {{ len site.Data.products }} products including pricing, supported platforms, headquarters, and more.
 
 ## Key Pages
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
     The open directory of digital signage software
   </h1>
   <p class="text-neutral-600 text-sm sm:text-base max-w-2xl mb-6">
-    Browse and compare {{ len .Pages }}+ products across pricing, platform support, and licensing. Community-maintained, no vendor bias.
+    Browse and compare {{ len .Pages }} products across pricing, platform support, and licensing. Community-maintained, no vendor bias.
   </p>
   <div class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-neutral-600">
     <span><span class="font-semibold text-neutral-900">{{ len .Pages }}</span> products</span>


### PR DESCRIPTION
The displayed product count is computed at build time (`len .Pages`), so the hardcoded "+" was redundant and the static "548+/500+" figures were stale (now 601).

- `layouts/index.html` — hero: `{{ len .Pages }}+ products` → `{{ len .Pages }} products`
- `layouts/_default/home.llms.txt` — "548+ products" → dynamic `{{ len site.Data.products }} products`
- `hugo.toml`, `content/products/_index.md`, `content/categories/cms/_index.md` — dropped the stale hardcoded "N+" from the SEO descriptions (static text, so removed the number rather than leaving a stale one)

Left untouched: the per-product **Active Screens** stats, where "+" legitimately means "at least".

Hugo builds cleanly; homepage now shows "601 products".