### PR TITLE
data: add docs links for 12 products; un-discontinue MediaSignage

### DIFF
--- a/content/updates/2026-07-26.md
+++ b/content/updates/2026-07-26.md
@@ -1,0 +1,34 @@
+---
+title: "Documentation links and a status fix"
+date: 2026-07-26
+description: "Added documentation links for 12 products and marked MediaSignage active."
+products:
+  - slug: aiscreen
+    change: "Added a link to product documentation: https://www.aiscreen.io/guides/"
+  - slug: brix
+    change: "Added a link to product documentation: https://brixsignage.com/guides/"
+  - slug: dynasign
+    change: "Added a link to product documentation: https://support.dynasign.net/hc/en-us"
+  - slug: menuboard-manager
+    change: "Added a link to product documentation: https://menumagik.ai/kb"
+  - slug: niio-art
+    change: "Added a link to product documentation: https://help.niio.com/en/"
+  - slug: screenbird
+    change: "Added a link to product documentation: https://screenbird.app/en/help"
+  - slug: seed-signage
+    change: "Added a link to product documentation: https://support.getseed.io/"
+  - slug: signos
+    change: "Added a link to product documentation: https://signosds.com/#downloads"
+  - slug: taplist
+    change: "Added a link to product documentation: https://help.taplist.io/"
+  - slug: tecastic
+    change: "Added a link to product documentation: https://support.tecastic.com/portal/en/home"
+  - slug: untappd-for-business
+    change: "Added a link to product documentation: https://help.untappd.com/hc/en-us/categories/360001962551-Untappd-for-Business"
+  - slug: vmcast
+    change: "Added a link to product documentation: https://help.viewmedica.com/"
+  - slug: mediasignage
+    change: "Marked as active; the product is no longer listed as discontinued."
+---
+
+Added documentation links for twelve products and corrected MediaSignage, which is active rather than discontinued.

--- a/data/products/aiscreen.yaml
+++ b/data/products/aiscreen.yaml
@@ -6,8 +6,8 @@ year_founded: 2021
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://www.aiscreen.io/guides/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/brix.yaml
+++ b/data/products/brix.yaml
@@ -5,8 +5,8 @@ website: https://brixsignage.com/
 year_founded: null
 headquarters: []
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://brixsignage.com/guides/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/dynasign.yaml
+++ b/data/products/dynasign.yaml
@@ -6,8 +6,8 @@ year_founded: 2003
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://support.dynasign.net/hc/en-us
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/mediasignage.yaml
+++ b/data/products/mediasignage.yaml
@@ -10,7 +10,7 @@ rss_feed_url: https://www.hughes.com/what-we-offer/digital-signage/cloud-based-d
 has_docs: false
 docs_url: null
 self_signup: false
-discontinued: true
+discontinued: false
 categories:
   - CMS
 platforms:

--- a/data/products/menuboard-manager.yaml
+++ b/data/products/menuboard-manager.yaml
@@ -6,8 +6,8 @@ year_founded: 2010
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://menumagik.ai/kb
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/niio-art.yaml
+++ b/data/products/niio-art.yaml
@@ -5,8 +5,8 @@ website: https://www.niio.com/
 year_founded: null
 headquarters: []
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://help.niio.com/en/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/screenbird.yaml
+++ b/data/products/screenbird.yaml
@@ -5,8 +5,8 @@ website: https://screenbird.app/
 year_founded: null
 headquarters: []
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://screenbird.app/en/help
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/seed-signage.yaml
+++ b/data/products/seed-signage.yaml
@@ -6,8 +6,8 @@ year_founded: null
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://support.getseed.io/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/signos.yaml
+++ b/data/products/signos.yaml
@@ -7,8 +7,8 @@ headquarters:
   - Turkey
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://signosds.com/#downloads
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/taplist.yaml
+++ b/data/products/taplist.yaml
@@ -6,8 +6,8 @@ year_founded: 2016
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://help.taplist.io/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/tecastic.yaml
+++ b/data/products/tecastic.yaml
@@ -6,8 +6,8 @@ year_founded: null
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://support.tecastic.com/portal/en/home
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/untappd-for-business.yaml
+++ b/data/products/untappd-for-business.yaml
@@ -6,8 +6,8 @@ year_founded: null
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://help.untappd.com/hc/en-us/categories/360001962551-Untappd-for-Business
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/vmcast.yaml
+++ b/data/products/vmcast.yaml
@@ -6,8 +6,8 @@ year_founded: null
 headquarters:
   - United States
 open_source: false
-has_docs: false
-docs_url: null
+has_docs: true
+docs_url: https://help.viewmedica.com/
 self_signup: false
 discontinued: false
 categories:


### PR DESCRIPTION
## What

Documentation review of the 23 recently added products, plus a status fix.

Set `has_docs: true` with a verified `docs_url` on the 12 that have real public
documentation (knowledge base, help center, or a proper user guide, not a bare
FAQ):

aiscreen, brix, dynasign, menuboard-manager, niio-art, screenbird, seed-signage,
signos, taplist, tecastic, untappd-for-business, vmcast.

The other 11 have no qualifying public docs and stay `has_docs: false`
(actionfigure, dsmenu, eye-in-media, onsignage, pixage, qsrsoft-tv,
right-media-solutions, screen-pulse, signstream, signjet, tsn). Several offer
only an FAQ, a contact form, or a login-gated portal, none of which count.

Also flips MediaSignage back to `discontinued: false`; the product (Hughes cloud
digital signage) is active.

## Notes for review

- menuboard-manager: knowledge base is hosted at menumagik.ai/kb (a related brand
  domain), rendered client-side.
- signos: docs are per-platform install guides linked from the homepage
  downloads section, so the URL is an anchor.

## Validation

`bun run check` passes on all 624 products.
