### PR TITLE
ci: collect-rss opens and auto-merges a PR instead of pushing to main

### DIFF
--- a/.github/workflows/collect-rss.yml
+++ b/.github/workflows/collect-rss.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   collect:
@@ -32,14 +33,24 @@ jobs:
       - name: Generate missing OG images
         run: bun run scripts/cli.ts gen-og
 
-      - name: Commit changes
+      - name: Open and merge pull request with changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/products/ data/feeds/ static/assets/og/
           if git diff --staged --quiet; then
             echo "No changes to commit."
-          else
-            git commit -m "chore: refresh RSS feed cache [skip ci]"
-            git push
+            exit 0
           fi
+          BRANCH="rss-cache/${GITHUB_RUN_ID}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: refresh RSS feed cache"
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: refresh RSS feed cache" \
+            --body "Automated daily RSS feed and OG image refresh."
+          # [skip ci] on the squash commit: the scheduled deploy picks up the cache
+          gh pr merge "$BRANCH" --squash --delete-branch \
+            --subject "chore: refresh RSS feed cache [skip ci]"


### PR DESCRIPTION
The daily Collect RSS Feeds cron failed because it pushed straight to protected main. It now commits to a branch, opens a PR, and squash-merges it with the Actions token. Branch protection keeps require-PR plus force-push/deletion blocks.