### PR TITLE
data: discover RSS feeds for products (32 found, 354 checked)

### DIFF
--- a/data/products/1glance.yaml
+++ b/data/products/1glance.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/22miles.yaml
+++ b/data/products/22miles.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://wiki.22miles.com/
+rss_feed_url: https://www.22miles.com/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/4dcast.yaml
+++ b/data/products/4dcast.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/acquire2go.yaml
+++ b/data/products/acquire2go.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ad-sign.yaml
+++ b/data/products/ad-sign.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/adcast.yaml
+++ b/data/products/adcast.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/admaster.yaml
+++ b/data/products/admaster.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/admefy.yaml
+++ b/data/products/admefy.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/admira.yaml
+++ b/data/products/admira.yaml
@@ -49,3 +49,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/adscreen.yaml
+++ b/data/products/adscreen.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/adsplay.yaml
+++ b/data/products/adsplay.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/aem-screens.yaml
+++ b/data/products/aem-screens.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/agentview.yaml
+++ b/data/products/agentview.yaml
@@ -54,3 +54,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/airtame.yaml
+++ b/data/products/airtame.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/aiscreen.yaml
+++ b/data/products/aiscreen.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/aitrios.yaml
+++ b/data/products/aitrios.yaml
@@ -23,3 +23,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/androidsignage.yaml
+++ b/data/products/androidsignage.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/anthias.yaml
+++ b/data/products/anthias.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/appcarousel.yaml
+++ b/data/products/appcarousel.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/appspace.yaml
+++ b/data/products/appspace.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/appsuite.yaml
+++ b/data/products/appsuite.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/atmospheretv.yaml
+++ b/data/products/atmospheretv.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/autora-dsm.yaml
+++ b/data/products/autora-dsm.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/avesign.yaml
+++ b/data/products/avesign.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/avsign-lite.yaml
+++ b/data/products/avsign-lite.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/aware.yaml
+++ b/data/products/aware.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/axistv.yaml
+++ b/data/products/axistv.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/beamer.yaml
+++ b/data/products/beamer.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/bharat-signage.yaml
+++ b/data/products/bharat-signage.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/bizplay.yaml
+++ b/data/products/bizplay.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/bohemica-signage.yaml
+++ b/data/products/bohemica-signage.yaml
@@ -56,3 +56,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/brandtv.yaml
+++ b/data/products/brandtv.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/bravia-signage-free.yaml
+++ b/data/products/bravia-signage-free.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/bricks.yaml
+++ b/data/products/bricks.yaml
@@ -48,3 +48,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/brix.yaml
+++ b/data/products/brix.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/buetema.yaml
+++ b/data/products/buetema.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/butikstv.yaml
+++ b/data/products/butikstv.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/canvaspro.yaml
+++ b/data/products/canvaspro.yaml
@@ -28,3 +28,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/carousel.yaml
+++ b/data/products/carousel.yaml
@@ -65,3 +65,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/casthub.yaml
+++ b/data/products/casthub.yaml
@@ -11,6 +11,7 @@ developer_portal_url: https://cast-hub.com/mcp/
 has_docs: true
 docs_url: https://cast-hub.com/docs/
 has_mcp: true
+rss_feed_url: https://cast-hub.com/feed/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/castmill.yaml
+++ b/data/products/castmill.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cayin.yaml
+++ b/data/products/cayin.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cenareo.yaml
+++ b/data/products/cenareo.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/centoview.yaml
+++ b/data/products/centoview.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/chrome-sign-builder.yaml
+++ b/data/products/chrome-sign-builder.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cirrus-screenhub.yaml
+++ b/data/products/cirrus-screenhub.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/clarity.yaml
+++ b/data/products/clarity.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/clearconnect.yaml
+++ b/data/products/clearconnect.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cleverlive.yaml
+++ b/data/products/cleverlive.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cleverq-picturemachine.yaml
+++ b/data/products/cleverq-picturemachine.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://www.cleverq.de/en/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/cloudshow.yaml
+++ b/data/products/cloudshow.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://cloud.show/Help
+rss_feed_url: https://feeds.feedburner.com/BinaryFortressSoftware/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/cloudyfy-tv.yaml
+++ b/data/products/cloudyfy-tv.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/coatro.yaml
+++ b/data/products/coatro.yaml
@@ -23,3 +23,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/comeen.yaml
+++ b/data/products/comeen.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/concerto.yaml
+++ b/data/products/concerto.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/connectedsign.yaml
+++ b/data/products/connectedsign.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/connectsignage.yaml
+++ b/data/products/connectsignage.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/coolerx.yaml
+++ b/data/products/coolerx.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/corevo.yaml
+++ b/data/products/corevo.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cortex.yaml
+++ b/data/products/cortex.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/crowntv.yaml
+++ b/data/products/crowntv.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cs-play.yaml
+++ b/data/products/cs-play.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/cyberlink-faceme.yaml
+++ b/data/products/cyberlink-faceme.yaml
@@ -23,3 +23,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dakboard.yaml
+++ b/data/products/dakboard.yaml
@@ -51,3 +51,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/datavisiooh.yaml
+++ b/data/products/datavisiooh.yaml
@@ -23,3 +23,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dcmcloud.yaml
+++ b/data/products/dcmcloud.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dex-manager.yaml
+++ b/data/products/dex-manager.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/digichief-mercury.yaml
+++ b/data/products/digichief-mercury.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/digimago.yaml
+++ b/data/products/digimago.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/digiongo.yaml
+++ b/data/products/digiongo.yaml
@@ -5,7 +5,7 @@ website: "https://digiongo.com/"
 year_founded: 2025
 headquarters: ["Serbia"]
 open_source: false
-rss_feed_url: null
+rss_feed_url: https://digiongo.com/rss.xml
 has_docs: false
 docs_url: null
 self_signup: false

--- a/data/products/digisign-play.yaml
+++ b/data/products/digisign-play.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/digital-signage-apps.yaml
+++ b/data/products/digital-signage-apps.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/digitalsigns-ai.yaml
+++ b/data/products/digitalsigns-ai.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dimedis.yaml
+++ b/data/products/dimedis.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/directable.yaml
+++ b/data/products/directable.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/disign.yaml
+++ b/data/products/disign.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/displai.yaml
+++ b/data/products/displai.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/display-now.yaml
+++ b/data/products/display-now.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/display-star.yaml
+++ b/data/products/display-star.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://www.kommatec-red.de/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/displaynxt.yaml
+++ b/data/products/displaynxt.yaml
@@ -50,3 +50,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/displio.yaml
+++ b/data/products/displio.yaml
@@ -47,3 +47,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/disploy.yaml
+++ b/data/products/disploy.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ditto.yaml
+++ b/data/products/ditto.yaml
@@ -51,3 +51,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/doohlabs-in-store-impact.yaml
+++ b/data/products/doohlabs-in-store-impact.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/doohly.yaml
+++ b/data/products/doohly.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/doohmain.yaml
+++ b/data/products/doohmain.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/door-tablet-signs.yaml
+++ b/data/products/door-tablet-signs.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://www.door-tablet.com/doors-help/get-started
+rss_feed_url: https://www.door-tablet.com/doortablet/feeds//help.xml
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/download-player.yaml
+++ b/data/products/download-player.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dripboards.yaml
+++ b/data/products/dripboards.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ds-suit.yaml
+++ b/data/products/ds-suit.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dsgo-pro.yaml
+++ b/data/products/dsgo-pro.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dsgo.yaml
+++ b/data/products/dsgo.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dsmenu.yaml
+++ b/data/products/dsmenu.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dsplay.yaml
+++ b/data/products/dsplay.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dvd-screensaver-maker.yaml
+++ b/data/products/dvd-screensaver-maker.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dvdify.yaml
+++ b/data/products/dvdify.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dydomite.yaml
+++ b/data/products/dydomite.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/dynasign.yaml
+++ b/data/products/dynasign.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/easescreen.yaml
+++ b/data/products/easescreen.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/easy-signage.yaml
+++ b/data/products/easy-signage.yaml
@@ -50,3 +50,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/easydisplay.yaml
+++ b/data/products/easydisplay.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/emagentv.yaml
+++ b/data/products/emagentv.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/enplug.yaml
+++ b/data/products/enplug.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/envoy-screens.yaml
+++ b/data/products/envoy-screens.yaml
@@ -42,3 +42,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/eumedia-dss.yaml
+++ b/data/products/eumedia-dss.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/evexi.yaml
+++ b/data/products/evexi.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/exclaim.yaml
+++ b/data/products/exclaim.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/explorestream.yaml
+++ b/data/products/explorestream.yaml
@@ -5,7 +5,7 @@ website: https://explorestream.com/
 year_founded: 2017
 headquarters: ["USA", "Canada"]
 open_source: false
-rss_feed_url: null
+rss_feed_url: https://explorestream.com/feed/
 has_docs: true
 docs_url: https://support.explorestream.com/
 self_signup: false

--- a/data/products/eye-in-media.yaml
+++ b/data/products/eye-in-media.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/eye-intelligence.yaml
+++ b/data/products/eye-intelligence.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/eyecon.yaml
+++ b/data/products/eyecon.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ez-ad-tv.yaml
+++ b/data/products/ez-ad-tv.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ezposter.yaml
+++ b/data/products/ezposter.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/fastpano.yaml
+++ b/data/products/fastpano.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/feedsome.yaml
+++ b/data/products/feedsome.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/fijee.yaml
+++ b/data/products/fijee.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/firmchannel.yaml
+++ b/data/products/firmchannel.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/five-faces.yaml
+++ b/data/products/five-faces.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://fivefaces.com.au/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/flagship-cms.yaml
+++ b/data/products/flagship-cms.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/flexitive.yaml
+++ b/data/products/flexitive.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/flosync.yaml
+++ b/data/products/flosync.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/framebaker.yaml
+++ b/data/products/framebaker.yaml
@@ -47,3 +47,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/frontface.yaml
+++ b/data/products/frontface.yaml
@@ -10,6 +10,7 @@ has_api: true
 developer_portal_url: https://www.mirabyte.com/en/frontface/features/plugin-sdk.html
 has_docs: true
 docs_url: https://www.mirabyte.com/en/support/knowledge-base.html
+rss_feed_url: https://blog.mirabyte.com/en/category/products/frontface/feed/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/garlic-signage.yaml
+++ b/data/products/garlic-signage.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/gibeon.yaml
+++ b/data/products/gibeon.yaml
@@ -81,3 +81,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/gotiger.yaml
+++ b/data/products/gotiger.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/grassfish-ixm-platform.yaml
+++ b/data/products/grassfish-ixm-platform.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/gymboard.yaml
+++ b/data/products/gymboard.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/haivision-coolsign.yaml
+++ b/data/products/haivision-coolsign.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/halo.yaml
+++ b/data/products/halo.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/helixcast.yaml
+++ b/data/products/helixcast.yaml
@@ -55,3 +55,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/helloscreens.yaml
+++ b/data/products/helloscreens.yaml
@@ -49,3 +49,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/hexa.yaml
+++ b/data/products/hexa.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/hexnode.yaml
+++ b/data/products/hexnode.yaml
@@ -53,3 +53,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/hipdeck.yaml
+++ b/data/products/hipdeck.yaml
@@ -42,3 +42,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/hydro-cms.yaml
+++ b/data/products/hydro-cms.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/hyper-net.yaml
+++ b/data/products/hyper-net.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/icompel.yaml
+++ b/data/products/icompel.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/idid.yaml
+++ b/data/products/idid.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/idplay.yaml
+++ b/data/products/idplay.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://akairo.fr/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/iisignage.yaml
+++ b/data/products/iisignage.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/iisignage2.yaml
+++ b/data/products/iisignage2.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ijjix.yaml
+++ b/data/products/ijjix.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/immerse.yaml
+++ b/data/products/immerse.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/impressbox.yaml
+++ b/data/products/impressbox.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/infini-sign.yaml
+++ b/data/products/infini-sign.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/infinitys-anima.yaml
+++ b/data/products/infinitys-anima.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/infobox.yaml
+++ b/data/products/infobox.yaml
@@ -42,3 +42,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/intelisa.yaml
+++ b/data/products/intelisa.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/interads.yaml
+++ b/data/products/interads.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/is-media.yaml
+++ b/data/products/is-media.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/itesmedia.yaml
+++ b/data/products/itesmedia.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/itotem.yaml
+++ b/data/products/itotem.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/jiosignage.yaml
+++ b/data/products/jiosignage.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/jiothings-jiosignage.yaml
+++ b/data/products/jiothings-jiosignage.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/juuno.yaml
+++ b/data/products/juuno.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/kiocast.yaml
+++ b/data/products/kiocast.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/kitcast.yaml
+++ b/data/products/kitcast.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/kiwi-signage.yaml
+++ b/data/products/kiwi-signage.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/koesio-tv.yaml
+++ b/data/products/koesio-tv.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/koke.yaml
+++ b/data/products/koke.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/korbyt.yaml
+++ b/data/products/korbyt.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/laqorr.yaml
+++ b/data/products/laqorr.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://documentation.laqorr.com/
+rss_feed_url: https://datmedia.com.au/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/leftclick.yaml
+++ b/data/products/leftclick.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/lg-supersign.yaml
+++ b/data/products/lg-supersign.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/lifeloop.yaml
+++ b/data/products/lifeloop.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/liqvid.yaml
+++ b/data/products/liqvid.yaml
@@ -48,3 +48,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/livesignage.yaml
+++ b/data/products/livesignage.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/loco-digital-signage.yaml
+++ b/data/products/loco-digital-signage.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/lookr.yaml
+++ b/data/products/lookr.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/loop-tv.yaml
+++ b/data/products/loop-tv.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/loopsign.yaml
+++ b/data/products/loopsign.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://loop24.no/loopsign/faq/
+rss_feed_url: https://loop24.no/feed/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/lumicast.yaml
+++ b/data/products/lumicast.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/lumoplay.yaml
+++ b/data/products/lumoplay.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/luna-screens.yaml
+++ b/data/products/luna-screens.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/m-cube.yaml
+++ b/data/products/m-cube.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://mcubedigital.com/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/m4b-wall.yaml
+++ b/data/products/m4b-wall.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/magic-mirror.yaml
+++ b/data/products/magic-mirror.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/magicinfo.yaml
+++ b/data/products/magicinfo.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/magicsign.yaml
+++ b/data/products/magicsign.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/magit-dsnet.yaml
+++ b/data/products/magit-dsnet.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/mangosigns.yaml
+++ b/data/products/mangosigns.yaml
@@ -50,3 +50,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/marve-ds.yaml
+++ b/data/products/marve-ds.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/master-signage.yaml
+++ b/data/products/master-signage.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/media4display.yaml
+++ b/data/products/media4display.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://www.telelogos.com/produits/fichiers/Media4Display_QuickStartGuide_EN_600.pdf
+rss_feed_url: https://www.telelogos.com/en/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/mediacast.yaml
+++ b/data/products/mediacast.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/mediacloud.yaml
+++ b/data/products/mediacloud.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/mediafusion.yaml
+++ b/data/products/mediafusion.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/mediatile.yaml
+++ b/data/products/mediatile.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/menara-ds.yaml
+++ b/data/products/menara-ds.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/menuzen.yaml
+++ b/data/products/menuzen.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/mirror.yaml
+++ b/data/products/mirror.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/moogx.yaml
+++ b/data/products/moogx.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/musthavemenus.yaml
+++ b/data/products/musthavemenus.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/mysignageportal.yaml
+++ b/data/products/mysignageportal.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/mysvd.yaml
+++ b/data/products/mysvd.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://svd-studio.fr/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/myvideospot.yaml
+++ b/data/products/myvideospot.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://docs.myvideospot.com/
+rss_feed_url: https://www.myvideospot.com/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/nanonation-commandpoint.yaml
+++ b/data/products/nanonation-commandpoint.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/navigo.yaml
+++ b/data/products/navigo.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/neon.yaml
+++ b/data/products/neon.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/netplay.yaml
+++ b/data/products/netplay.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/netsign.yaml
+++ b/data/products/netsign.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/newvision.yaml
+++ b/data/products/newvision.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/novacloud.yaml
+++ b/data/products/novacloud.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/novods.yaml
+++ b/data/products/novods.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/nowsignage.yaml
+++ b/data/products/nowsignage.yaml
@@ -52,3 +52,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/nsigntv.yaml
+++ b/data/products/nsigntv.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/numia.yaml
+++ b/data/products/numia.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/nusyn.yaml
+++ b/data/products/nusyn.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/nutrislice.yaml
+++ b/data/products/nutrislice.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/nuvelar-display.yaml
+++ b/data/products/nuvelar-display.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/obscreen.yaml
+++ b/data/products/obscreen.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/omnivex.yaml
+++ b/data/products/omnivex.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/one-ds.yaml
+++ b/data/products/one-ds.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/oneblending.yaml
+++ b/data/products/oneblending.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/onq-cms.yaml
+++ b/data/products/onq-cms.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/onsign-tv.yaml
+++ b/data/products/onsign-tv.yaml
@@ -48,3 +48,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/onsignage.yaml
+++ b/data/products/onsignage.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/opensign.yaml
+++ b/data/products/opensign.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/opensignage.yaml
+++ b/data/products/opensignage.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://www.opensignage.com/rss/feed.xml
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/optisigns.yaml
+++ b/data/products/optisigns.yaml
@@ -58,3 +58,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ozonet.yaml
+++ b/data/products/ozonet.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/pandopad.yaml
+++ b/data/products/pandopad.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/philips-cmnd.yaml
+++ b/data/products/philips-cmnd.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/piads.yaml
+++ b/data/products/piads.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/pickcel.yaml
+++ b/data/products/pickcel.yaml
@@ -50,3 +50,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/picturemachine4.yaml
+++ b/data/products/picturemachine4.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/pilottv.yaml
+++ b/data/products/pilottv.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/pisignage.yaml
+++ b/data/products/pisignage.yaml
@@ -49,3 +49,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/pixelnebula.yaml
+++ b/data/products/pixelnebula.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/pixilab-blocks.yaml
+++ b/data/products/pixilab-blocks.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/playshield.yaml
+++ b/data/products/playshield.yaml
@@ -46,3 +46,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/plustv.yaml
+++ b/data/products/plustv.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/poppulo.yaml
+++ b/data/products/poppulo.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/posterbooking.yaml
+++ b/data/products/posterbooking.yaml
@@ -46,3 +46,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/publicview.yaml
+++ b/data/products/publicview.yaml
@@ -50,3 +50,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/pyrosign.yaml
+++ b/data/products/pyrosign.yaml
@@ -51,3 +51,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/q-play.yaml
+++ b/data/products/q-play.yaml
@@ -47,3 +47,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/qmatic-display.yaml
+++ b/data/products/qmatic-display.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/quickesign.yaml
+++ b/data/products/quickesign.yaml
@@ -54,3 +54,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/radix.yaml
+++ b/data/products/radix.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/raspberry-digital-signage.yaml
+++ b/data/products/raspberry-digital-signage.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://www.binaryemotions.com/raspberry-digital-signage-docs
+rss_feed_url: https://www.binaryemotions.com/feed/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/reflect-adlogic.yaml
+++ b/data/products/reflect-adlogic.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/reflect-experience.yaml
+++ b/data/products/reflect-experience.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/reflectview.yaml
+++ b/data/products/reflectview.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/repeat-signage.yaml
+++ b/data/products/repeat-signage.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/retailrotor.yaml
+++ b/data/products/retailrotor.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/revel-digital.yaml
+++ b/data/products/revel-digital.yaml
@@ -41,3 +41,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/right-media-solutions.yaml
+++ b/data/products/right-media-solutions.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/rockbot.yaml
+++ b/data/products/rockbot.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/rs-cms.yaml
+++ b/data/products/rs-cms.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/rt-screens.yaml
+++ b/data/products/rt-screens.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ryarc-campaignmanager.yaml
+++ b/data/products/ryarc-campaignmanager.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://www.ryarc.net/CM6Help-Stage/
+rss_feed_url: https://ryarc.com/feed/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/sabercom.yaml
+++ b/data/products/sabercom.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sageview.yaml
+++ b/data/products/sageview.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/saii.yaml
+++ b/data/products/saii.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://saga-digital.fr/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/samsung-vxt.yaml
+++ b/data/products/samsung-vxt.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/scalefusion.yaml
+++ b/data/products/scalefusion.yaml
@@ -56,3 +56,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screen-canvas.yaml
+++ b/data/products/screen-canvas.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screen-pulse.yaml
+++ b/data/products/screen-pulse.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screenaai.yaml
+++ b/data/products/screenaai.yaml
@@ -56,3 +56,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screenberry.yaml
+++ b/data/products/screenberry.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screenbird.yaml
+++ b/data/products/screenbird.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screencloud.yaml
+++ b/data/products/screencloud.yaml
@@ -47,3 +47,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screendrive.yaml
+++ b/data/products/screendrive.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screenfeed.yaml
+++ b/data/products/screenfeed.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screenivo.yaml
+++ b/data/products/screenivo.yaml
@@ -44,3 +44,4 @@ languages: []
 screenshots: []
 last_verified: "2026-04-16"
 has_sso: true
+# 2026-07-27 - RSS feed not found

--- a/data/products/screenlite.yaml
+++ b/data/products/screenlite.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screenmanager.yaml
+++ b/data/products/screenmanager.yaml
@@ -48,3 +48,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screensoft.yaml
+++ b/data/products/screensoft.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/screentinker.yaml
+++ b/data/products/screentinker.yaml
@@ -63,3 +63,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sdbcomplex.yaml
+++ b/data/products/sdbcomplex.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sedco.yaml
+++ b/data/products/sedco.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/seencmp.yaml
+++ b/data/products/seencmp.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sensorylab.yaml
+++ b/data/products/sensorylab.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/shop-iq.yaml
+++ b/data/products/shop-iq.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sign-presenter.yaml
+++ b/data/products/sign-presenter.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signa.yaml
+++ b/data/products/signa.yaml
@@ -56,3 +56,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signage-ninja.yaml
+++ b/data/products/signage-ninja.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://signage.ninja/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/signage-orchestrator.yaml
+++ b/data/products/signage-orchestrator.yaml
@@ -10,6 +10,7 @@ license: GPL-3.0-only
 source_code_url: https://github.com/marco-buratto/signage-orchestrator
 has_docs: true
 docs_url: https://github.com/marco-buratto/signage-orchestrator#readme
+rss_feed_url: https://www.binaryemotions.com/feed/
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/signage-rocket.yaml
+++ b/data/products/signage-rocket.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signage-soft.yaml
+++ b/data/products/signage-soft.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://www.signagesoft.com/?feed=rss2
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/signage-studio.yaml
+++ b/data/products/signage-studio.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signagect.yaml
+++ b/data/products/signagect.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signageflow.yaml
+++ b/data/products/signageflow.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signagemx.yaml
+++ b/data/products/signagemx.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signageos.yaml
+++ b/data/products/signageos.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signao.yaml
+++ b/data/products/signao.yaml
@@ -54,3 +54,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signboox.yaml
+++ b/data/products/signboox.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signet.yaml
+++ b/data/products/signet.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signio.yaml
+++ b/data/products/signio.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signips.yaml
+++ b/data/products/signips.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signital.yaml
+++ b/data/products/signital.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signmate.yaml
+++ b/data/products/signmate.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signos.yaml
+++ b/data/products/signos.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/signstream.yaml
+++ b/data/products/signstream.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/simplesignage.yaml
+++ b/data/products/simplesignage.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sippo.yaml
+++ b/data/products/sippo.yaml
@@ -48,3 +48,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sitekiosk.yaml
+++ b/data/products/sitekiosk.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/sklera.yaml
+++ b/data/products/sklera.yaml
@@ -56,3 +56,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/skoop.yaml
+++ b/data/products/skoop.yaml
@@ -49,3 +49,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/skratch.yaml
+++ b/data/products/skratch.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/skysignage.yaml
+++ b/data/products/skysignage.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/smart-prospective.yaml
+++ b/data/products/smart-prospective.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/smartersign.yaml
+++ b/data/products/smartersign.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/smartinfo.yaml
+++ b/data/products/smartinfo.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/smilcontrol.yaml
+++ b/data/products/smilcontrol.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/solix.yaml
+++ b/data/products/solix.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/spectroo.yaml
+++ b/data/products/spectroo.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://docs.spectroo.eu/?lang=en
+rss_feed_url: https://spectroo.eu/feed/?lang=en
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/spinetix-arya.yaml
+++ b/data/products/spinetix-arya.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/spinetix-elementi.yaml
+++ b/data/products/spinetix-elementi.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/splashtiles.yaml
+++ b/data/products/splashtiles.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/squizz.yaml
+++ b/data/products/squizz.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/strandvision.yaml
+++ b/data/products/strandvision.yaml
@@ -42,3 +42,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/supacms.yaml
+++ b/data/products/supacms.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/surevideo.yaml
+++ b/data/products/surevideo.yaml
@@ -44,3 +44,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/swift-signage.yaml
+++ b/data/products/swift-signage.yaml
@@ -53,3 +53,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/switchboard.yaml
+++ b/data/products/switchboard.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://coatesgroup.com/feed/insights
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/szcope.yaml
+++ b/data/products/szcope.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://pos-experience.de/feed/
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/taplist.yaml
+++ b/data/products/taplist.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://help.taplist.io/
+rss_feed_url: https://taplist.io/blog/rss.xml
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/targetr.yaml
+++ b/data/products/targetr.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/tcadvert.yaml
+++ b/data/products/tcadvert.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/tcit.yaml
+++ b/data/products/tcit.yaml
@@ -6,7 +6,7 @@ year_founded: null
 headquarters:
   - Taiwan
 open_source: false
-rss_feed_url: null
+rss_feed_url: https://tcit-tw.com/en/feed/
 has_docs: false
 docs_url: null
 self_signup: false

--- a/data/products/tdm-signage.yaml
+++ b/data/products/tdm-signage.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://tdmsignage.zendesk.com/hc/en-us
+rss_feed_url: https://tdmsignage.com/feed/?lang=en
 self_signup: true
 discontinued: false
 categories:

--- a/data/products/tecastic.yaml
+++ b/data/products/tecastic.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/telefonica-tech.yaml
+++ b/data/products/telefonica-tech.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/telemetrytv.yaml
+++ b/data/products/telemetrytv.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/teos.yaml
+++ b/data/products/teos.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/tigermeeting.yaml
+++ b/data/products/tigermeeting.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/tippler-tv.yaml
+++ b/data/products/tippler-tv.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/trillboards.yaml
+++ b/data/products/trillboards.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/tsn.yaml
+++ b/data/products/tsn.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/tvcast-pro.yaml
+++ b/data/products/tvcast-pro.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/tvque.yaml
+++ b/data/products/tvque.yaml
@@ -47,3 +47,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/uncanal.yaml
+++ b/data/products/uncanal.yaml
@@ -48,3 +48,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/uniguest-hub.yaml
+++ b/data/products/uniguest-hub.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/uniguest-mediastar.yaml
+++ b/data/products/uniguest-mediastar.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/uniguest-onelan.yaml
+++ b/data/products/uniguest-onelan.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/uniguest-tripleplay.yaml
+++ b/data/products/uniguest-tripleplay.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/uniview.yaml
+++ b/data/products/uniview.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/untappd-for-business.yaml
+++ b/data/products/untappd-for-business.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/upshow.yaml
+++ b/data/products/upshow.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/usb-slideshow.yaml
+++ b/data/products/usb-slideshow.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/userful-engage.yaml
+++ b/data/products/userful-engage.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vcastplay.yaml
+++ b/data/products/vcastplay.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/venus-control-suite.yaml
+++ b/data/products/venus-control-suite.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vertika.yaml
+++ b/data/products/vertika.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vibe-fyi.yaml
+++ b/data/products/vibe-fyi.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: true
 docs_url: https://support.vibe.fyi/portal/en/kb
+rss_feed_url: https://www.vibe.fyi/feeds/posts/rss/?post_category_id=87
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/vicont.yaml
+++ b/data/products/vicont.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vidarti.yaml
+++ b/data/products/vidarti.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/videomood.yaml
+++ b/data/products/videomood.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/viewneo.yaml
+++ b/data/products/viewneo.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vigitsign.yaml
+++ b/data/products/vigitsign.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/virtusignage.yaml
+++ b/data/products/virtusignage.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/visiobox.yaml
+++ b/data/products/visiobox.yaml
@@ -37,3 +37,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/visual-art-signage-player.yaml
+++ b/data/products/visual-art-signage-player.yaml
@@ -42,3 +42,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/visuscreen.yaml
+++ b/data/products/visuscreen.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vizansign.yaml
+++ b/data/products/vizansign.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vmcast.yaml
+++ b/data/products/vmcast.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vnnox.yaml
+++ b/data/products/vnnox.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vsplayer.yaml
+++ b/data/products/vsplayer.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/vuepilot.yaml
+++ b/data/products/vuepilot.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wallboard.yaml
+++ b/data/products/wallboard.yaml
@@ -45,3 +45,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wallflower.yaml
+++ b/data/products/wallflower.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wand.yaml
+++ b/data/products/wand.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/watchout.yaml
+++ b/data/products/watchout.yaml
@@ -30,3 +30,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wauly.yaml
+++ b/data/products/wauly.yaml
@@ -44,3 +44,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wejha.yaml
+++ b/data/products/wejha.yaml
@@ -38,3 +38,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wesion.yaml
+++ b/data/products/wesion.yaml
@@ -8,6 +8,7 @@ headquarters:
 open_source: false
 has_docs: false
 docs_url: null
+rss_feed_url: https://www.wesion.hu/blog-feed.xml
 self_signup: false
 discontinued: false
 categories:

--- a/data/products/wesual.yaml
+++ b/data/products/wesual.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wicanvas.yaml
+++ b/data/products/wicanvas.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/wilyer.yaml
+++ b/data/products/wilyer.yaml
@@ -47,3 +47,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/worldvds.yaml
+++ b/data/products/worldvds.yaml
@@ -43,3 +43,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/x-sign.yaml
+++ b/data/products/x-sign.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/xignage.yaml
+++ b/data/products/xignage.yaml
@@ -35,3 +35,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/xiphias.yaml
+++ b/data/products/xiphias.yaml
@@ -33,3 +33,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/xogo.yaml
+++ b/data/products/xogo.yaml
@@ -46,3 +46,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/xopvision.yaml
+++ b/data/products/xopvision.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/xtravu.yaml
+++ b/data/products/xtravu.yaml
@@ -32,3 +32,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/xtremesignage.yaml
+++ b/data/products/xtremesignage.yaml
@@ -36,3 +36,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/yap-create.yaml
+++ b/data/products/yap-create.yaml
@@ -29,3 +29,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/ycd-ramp.yaml
+++ b/data/products/ycd-ramp.yaml
@@ -40,3 +40,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/yugna.yaml
+++ b/data/products/yugna.yaml
@@ -39,3 +39,4 @@ languages: []
 screenshots: []
 last_verified: null
 has_sso: true
+# 2026-07-27 - RSS feed not found

--- a/data/products/zebrix.yaml
+++ b/data/products/zebrix.yaml
@@ -39,3 +39,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/zeroframe.yaml
+++ b/data/products/zeroframe.yaml
@@ -34,3 +34,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found

--- a/data/products/zynchro.yaml
+++ b/data/products/zynchro.yaml
@@ -31,3 +31,4 @@ support_channels: []
 languages: []
 screenshots: []
 last_verified: null
+# 2026-07-27 - RSS feed not found


### PR DESCRIPTION
## What

Swept every active product that had a website but no `rss_feed_url` (386 in total) and tried to discover a real RSS/Atom feed for each.

- **32 feeds found and recorded** as `rss_feed_url`.
- **354 marked** with a dated YAML comment `# 2026-07-27 - RSS feed not found`, so we know they were checked and do not re-scan them.

## How feeds were discovered

For each product: fetch the homepage and read any `<link rel="alternate" type="application/rss+xml|atom+xml">`, then probe common feed paths (`/feed/`, `/rss.xml`, `/atom.xml`, etc.). Every candidate is validated by fetching it and confirming it is actually a feed (contains `<rss>`, `<feed>`, `<channel>`, or `<rdf>`), not just any XML. First validated hit wins, preferring the declared `<link>` feed.

## Notes

- The not-found marker is a YAML comment, so it does not render on the product page; it is an internal "checked on this date" marker.
- A few feeds live on the vendor's parent or company domain rather than the product's own (e.g. Media4Display -> telelogos.com, Switchboard -> coatesgroup.com, frontface -> mirabyte's blog). These are the correct company behind the product and each validated as a real feed.
- Hit rate was ~8%; RSS feeds are simply uncommon on these vendor sites.

## Validation

`bun run check` passes on all 625 products. `hugo --minify` builds clean.
