### PR TITLE
content: add TVpilot.App (#235)

### DIFF
--- a/assets/logos/dark/tvpilot-app.svg
+++ b/assets/logos/dark/tvpilot-app.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none">
+  <rect width="48" height="48" rx="12" fill="#003a60"/>
+  <rect x="27.5" y="10" width="13.5" height="22" rx="3.75" fill="none" stroke="#85ABC7" stroke-width="3.25"/>
+  <rect x="7" y="22.5" width="22" height="15" rx="3.75" fill="#003a60" stroke="#003a60" stroke-width="7.5"/>
+  <rect x="7" y="22.5" width="22" height="15" rx="3.75" fill="none" stroke="#ffffff" stroke-width="3.25"/>
+</svg>

--- a/content/updates/2026-08-16.md
+++ b/content/updates/2026-08-16.md
@@ -1,19 +1,22 @@
 ---
-title: "Two new products, and SkyMedia marked discontinued"
+title: "Three new products, and SkyMedia marked discontinued"
 date: 2026-08-16
-description: "Added Nimbus808 and WhiteCore.AI to the directory, and marked SkyMedia discontinued."
+description: "Added Nimbus808, WhiteCore.AI, and TVpilot.App to the directory, and marked SkyMedia discontinued."
 products:
   - slug: nimbus808
     change: "New listing: US cloud CMS aimed at small businesses, with a 90-day free trial, plans from $9/month for two displays, and playback in a browser or on Fire TV and Android TV devices."
   - slug: whitecore-ai
     change: "New listing: Australian cloud CMS with optional Vision AI camera analytics, players for Windows, macOS, Linux, and Raspberry Pi, and plans from A$29/month."
+  - slug: tvpilot-app
+    change: "New listing: Dutch cloud CMS with a permanent free tier for one screen, paid plans from EUR 5/month, and browser-based playback on Raspberry Pi, Fire TV, and Android TV."
   - slug: skymedia
     change: "Marked discontinued and removed the product news feed. The domain no longer offers digital signage and now hosts an unrelated lifestyle blog."
 ---
 
-Two products joined the directory, both suggested by the community:
+Three products joined the directory, all suggested by the community:
 
 - **Nimbus808**, a cloud platform from Washington state that turns an existing TV into a sign, either through the TV's browser or a streaming stick, with templates and drag-and-drop editing aimed at people who have never run signage before.
 - **WhiteCore.AI**, an Australian CMS that pairs content publishing with camera-based venue analytics. Cameras are optional, and on the higher plans they can measure visitors, dwell time, and queues, then trigger content changes on the screens.
+- **TVpilot.App**, a Dutch CMS built around cheap hardware. Screens run in a browser, so a Raspberry Pi, a Fire TV Stick, or the TV itself will do, and the free plan covers one screen indefinitely.
 
 SkyMedia is now marked discontinued. Its Singapore domain has been turned into a lifestyle blog covering parenting, food, and property, with no sign of the signage business, and the RSS feed that used to carry product news has been removed from the listing.

--- a/data/products/tvpilot-app.yaml
+++ b/data/products/tvpilot-app.yaml
@@ -1,0 +1,67 @@
+name: TVpilot.App
+slug: tvpilot-app
+description: Cloud digital signage CMS with a permanent free tier, running on Raspberry Pi, Fire TV, Android TV, or any modern browser.
+website: https://tvpilot.app/
+year_founded: 2026
+headquarters:
+  - Netherlands
+open_source: false
+has_docs: false
+docs_url: null
+self_signup: true
+discontinued: false
+categories:
+  - CMS
+platforms:
+  - Web Browser
+  - Raspberry Pi
+  - Linux
+  - Android
+  - Fire OS
+models:
+  - delivery: cloud
+    free_trial: false
+    pricing_available: true
+    has_freemium: true
+    pricing:
+      - name: Free
+        payment_model: free
+        billing_basis: flat_rate
+        monthly: 0
+        yearly: 0
+        included_screens: 1
+        max_screens: 1
+      - name: Starter
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 5
+        yearly: null
+        included_screens: 5
+        max_screens: 5
+      - name: Pro
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: 19
+        yearly: null
+        included_screens: 25
+        max_screens: 25
+      - name: Business
+        payment_model: subscription
+        billing_basis: flat_rate
+        monthly: null
+        yearly: null
+stats: {}
+notes:
+  - Pricing is listed in EUR (Free €0, Starter €5, Pro €19 per month). Business is custom priced for 25 or more screens.
+  - Plans are also capped by storage (250 MB on Free, 1 GB on Starter, 10 GB on Pro).
+  - There is no time-limited trial. The free plan is permanent and needs no credit card.
+  - Playback is browser-based, including on Fire TV Stick through the Silk browser and on Android TV. Raspberry Pi uses a one-command Chromium install.
+  - SSO, SAML, and audit logs are offered on request rather than as standard plan features.
+features: []
+integrations: []
+target_audience: []
+deployment_options: []
+support_channels: []
+languages: []
+screenshots: []
+last_verified: null


### PR DESCRIPTION
Adds TVpilot.App, a Dutch cloud CMS, from the submission in #235. Extends today's existing `2026-08-16.md` release note rather than adding a new file.

Data verified against tvpilot.app:

- Four plans recorded as flat rate with their screen caps: Free EUR 0 (1 screen), Starter EUR 5 (5), Pro EUR 19 (25), Business custom (25+). Prices stored as published in EUR with a note on the currency.
- `free_trial: false` and `has_freemium: true`. The site is explicit that there's no trial clock, the free plan is permanent.
- Platforms are Web Browser, Raspberry Pi, Linux, Android, and Fire OS. Playback is browser-based everywhere, including Fire TV Stick via Silk and Android TV, with a one-command Chromium install on the Pi. The submission also listed iOS and Chrome OS; nothing on the site supports iOS, and "Chrome Browser" on the devices list is the browser, already covered by Web Browser.
- Storage caps per plan and the on-request SSO/SAML/audit-log options are recorded in notes, since there are no fields for them.

One thing left out: the submission reports 100+ total screens sourced to tvpilot.app, but that figure doesn't appear anywhere on the site, so `stats` stays empty. Happy to add it with a citable source.

Logo is the site icon (SVG, 485 bytes) in `assets/logos/dark/`.

Closes #235