### PR TITLE
feat: sync homepage filters to URL params

### DIFF
--- a/assets/ts/home-url-sync.ts
+++ b/assets/ts/home-url-sync.ts
@@ -1,0 +1,140 @@
+import type { FilterEngine, FilterState } from './filter'
+
+/*
+	URL sync for the homepage list. Kept separate from url-sync.ts because the two
+	pages start from different defaults: /products/ opens on the CMS category with
+	both licence checkboxes ticked, the homepage opens with nothing selected. Here
+	only non-default values are written, so an unfiltered homepage keeps a clean URL
+	and a shared link carries exactly the filters the user turned on.
+*/
+
+/** URL param name paired with the FilterState key it drives. */
+const BOOLEAN_PARAMS: Array<[string, keyof FilterState]> = [
+	['openSource', 'showOpenSource'],
+	['proprietary', 'showProprietary'],
+	['free', 'showFreeOnly'],
+	['freeTrial', 'showFreeTrialOnly'],
+	['freemium', 'showFreemiumOnly'],
+	['discontinued', 'showDiscontinuedOnly'],
+	['hideDiscontinued', 'hideDiscontinued'],
+	['signupIsOpenOnly', 'signupIsOpenOnly'],
+]
+
+const LIST_PARAMS: Array<[string, keyof FilterState]> = [
+	['platforms', 'selectedPlatforms'],
+	['hq', 'selectedHQ'],
+]
+
+export interface ParsedHomeUrl {
+	state: Partial<FilterState>
+	page: number
+}
+
+/** Reads a query string into the filter state it encodes. Unknown and malformed params are ignored. */
+export function parseHomeUrl(search: string): ParsedHomeUrl {
+	const params = new URLSearchParams(search)
+	const state: Record<string, unknown> = {}
+
+	const term = params.get('search')
+	if (term) state.searchTerm = term
+
+	for (const [param, key] of BOOLEAN_PARAMS) {
+		if (params.get(param) === 'true') state[key] = true
+	}
+
+	for (const [param, key] of LIST_PARAMS) {
+		const values = (params.get(param) || '')
+			.split(',')
+			.map((value) => value.trim())
+			.filter(Boolean)
+		if (values.length > 0) state[key] = values
+	}
+
+	const page = Number.parseInt(params.get('page') || '', 10)
+
+	return {
+		state: state as Partial<FilterState>,
+		page: Number.isNaN(page) || page < 1 ? 1 : page,
+	}
+}
+
+/** Every param this module owns. Anything else in the URL is left alone. */
+const OWNED_PARAMS = new Set([
+	'search',
+	'page',
+	...BOOLEAN_PARAMS.map(([param]) => param),
+	...LIST_PARAMS.map(([param]) => param),
+])
+
+/**
+ * Builds the query string for a state, including the leading "?". Returns "" when nothing is filtered.
+ * Params from `preserve` that this module does not own are carried through, so filtering does not
+ * strip campaign tags off a link someone followed to get here.
+ */
+export function buildHomeUrl(state: FilterState, page = 1, preserve = ''): string {
+	const params = new URLSearchParams()
+
+	for (const [key, value] of new URLSearchParams(preserve)) {
+		if (!OWNED_PARAMS.has(key)) params.append(key, value)
+	}
+
+	if (state.searchTerm) params.set('search', state.searchTerm)
+
+	for (const [param, key] of BOOLEAN_PARAMS) {
+		if (state[key]) params.set(param, 'true')
+	}
+
+	for (const [param, key] of LIST_PARAMS) {
+		const values = state[key] as string[]
+		if (values.length > 0) params.set(param, values.join(','))
+	}
+
+	if (page > 1) params.set('page', String(page))
+
+	const query = params.toString()
+	return query ? `?${query}` : ''
+}
+
+export function initHomeUrlSync(engine: FilterEngine, onRestore?: () => void): void {
+	const { state, page } = parseHomeUrl(window.location.search)
+
+	if (Object.keys(state).length > 0) {
+		engine.setState(state)
+		syncControlsFromState(engine)
+		onRestore?.()
+	}
+
+	// setState resets to page 1, so the page is restored after it
+	if (page > 1) {
+		engine.setPage(Math.min(page, engine.getPageInfo().total))
+	}
+
+	const listPath = window.location.pathname
+
+	engine.onChange(() => {
+		// The product modal swaps the URL for the product's own path while it is open.
+		// Leave it alone until it closes, rather than stamping filters onto that URL.
+		if (window.location.pathname !== listPath) return
+		const query = buildHomeUrl(engine.getState(), engine.getPageInfo().current, window.location.search)
+		window.history.replaceState({}, '', `${listPath}${query}`)
+	})
+}
+
+function syncControlsFromState(engine: FilterEngine): void {
+	const state = engine.getState()
+
+	const searchInput = document.querySelector<HTMLInputElement>('#search-input')
+	if (searchInput) searchInput.value = state.searchTerm
+
+	for (const cb of document.querySelectorAll<HTMLInputElement>('#hide-discontinued, #hide-discontinued-mobile')) {
+		cb.checked = state.hideDiscontinued
+	}
+
+	for (const cb of document.querySelectorAll<HTMLInputElement>('[data-platform-checkbox]')) {
+		cb.checked = state.selectedPlatforms.includes(cb.dataset.platformCheckbox || '')
+	}
+
+	for (const cb of document.querySelectorAll<HTMLInputElement>('[data-hq-checkbox]')) {
+		cb.checked = state.selectedHQ.includes(cb.dataset.hqCheckbox || '')
+	}
+}

--- a/assets/ts/main.ts
+++ b/assets/ts/main.ts
@@ -2,6 +2,7 @@ import { initAuthenticationDropdown } from './authentication-dropdown'
 import { initComplianceDropdown } from './compliance-dropdown'
 import { FilterEngine } from './filter'
 import { initGitHubStars } from './github-stars'
+import { initHomeUrlSync } from './home-url-sync'
 import { initProductModal } from './modal'
 import { initPlatformDropdown } from './platform-dropdown'
 import { initSearch } from './search'
@@ -548,6 +549,11 @@ function initHomePage(productList: HTMLElement): void {
 				scrollToList()
 			}
 		})
+
+	initHomeUrlSync(engine, () => {
+		syncTypePills(typePills, engine)
+		updateMobileFilterBadge()
+	})
 
 	engine.applyFilters()
 	initProductModal(productList, engine)

--- a/assets/ts/modal.ts
+++ b/assets/ts/modal.ts
@@ -1,7 +1,9 @@
 import type { FilterEngine } from './filter'
 
 export function initProductModal(productList: HTMLElement, engine: FilterEngine): void {
-	const listUrl = location.href
+	// Captured each time the modal opens, so closing returns to the list URL as it
+	// was then, filters and all, rather than to a snapshot from page load.
+	let listUrl = location.href
 	let currentIndex = -1
 	let isOpen = false
 	const cache = new Map<string, string>()
@@ -109,7 +111,10 @@ export function initProductModal(productList: HTMLElement, engine: FilterEngine)
 			}),
 		)
 		openLink.href = href
-		if (pushState) history.pushState({ modal: true, href }, '', href)
+		if (pushState) {
+			listUrl = location.href
+			history.pushState({ modal: true, href }, '', href)
+		}
 		updateNav()
 		await loadProduct(href)
 	}

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.0/schema.json",
 	"files": {
-		"includes": ["assets/ts/**/*.ts", "scripts/**/*.ts"]
+		"includes": ["assets/ts/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts"]
 	},
 	"formatter": {
 		"indentStyle": "tab",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "hugo server --minify",
     "cli": "bun run scripts/cli.ts",
     "check": "bun run scripts/cli.ts check",
+    "test": "bun test",
     "add": "bun run scripts/cli.ts add",
     "gen:og": "bun run scripts/cli.ts gen-og",
     "gen:terms": "bun run scripts/cli.ts gen-terms",
@@ -22,8 +23,8 @@
     "discover:rss": "bun run scripts/cli.ts discover-rss",
     "fetch-feeds": "bun run scripts/cli.ts fetch-feeds",
     "check:urls": "bun run scripts/cli.ts check-urls",
-    "lint": "bunx biome check assets/ts/ scripts/",
-    "lint:fix": "bunx biome check --write assets/ts/ scripts/"
+    "lint": "bunx biome check assets/ts/ scripts/ tests/",
+    "lint:fix": "bunx biome check --write assets/ts/ scripts/ tests/"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.0",

--- a/tests/home-url-sync.test.ts
+++ b/tests/home-url-sync.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test'
+import type { FilterState } from '../assets/ts/filter'
+import { buildHomeUrl, parseHomeUrl } from '../assets/ts/home-url-sync'
+
+/** Homepage defaults: nothing selected. initHomePage() clears category and both licence flags. */
+function homeState(overrides: Partial<FilterState> = {}): FilterState {
+	return {
+		category: '',
+		searchTerm: '',
+		showOpenSource: false,
+		showProprietary: false,
+		showDiscontinuedOnly: false,
+		hideDiscontinued: false,
+		showFreeTrialOnly: false,
+		showFreemiumOnly: false,
+		showFreeOnly: false,
+		selectedPlatforms: [],
+		selectedHQ: [],
+		selectedCompliance: [],
+		selectedAuthentication: [],
+		signupIsOpenOnly: false,
+		...overrides,
+	}
+}
+
+describe('parseHomeUrl', () => {
+	test('returns an empty state for a bare URL', () => {
+		const { state, page } = parseHomeUrl('')
+		expect(state).toEqual({})
+		expect(page).toBe(1)
+	})
+
+	test('reads the search term', () => {
+		expect(parseHomeUrl('?search=kiosk').state).toEqual({ searchTerm: 'kiosk' })
+	})
+
+	test('ignores an empty search term', () => {
+		expect(parseHomeUrl('?search=').state).toEqual({})
+	})
+
+	test('reads every boolean filter', () => {
+		const query =
+			'?openSource=true&proprietary=true&free=true&freeTrial=true&freemium=true&discontinued=true&hideDiscontinued=true&signupIsOpenOnly=true'
+		expect(parseHomeUrl(query).state).toEqual({
+			showOpenSource: true,
+			showProprietary: true,
+			showFreeOnly: true,
+			showFreeTrialOnly: true,
+			showFreemiumOnly: true,
+			showDiscontinuedOnly: true,
+			hideDiscontinued: true,
+			signupIsOpenOnly: true,
+		})
+	})
+
+	test('only "true" enables a boolean, so a stale false is not applied as a filter', () => {
+		expect(parseHomeUrl('?openSource=false&free=1&freeTrial=yes').state).toEqual({})
+	})
+
+	test('splits list filters on commas', () => {
+		expect(parseHomeUrl('?platforms=Android,Tizen&hq=usa,germany').state).toEqual({
+			selectedPlatforms: ['Android', 'Tizen'],
+			selectedHQ: ['usa', 'germany'],
+		})
+	})
+
+	test('trims blanks out of list filters', () => {
+		expect(parseHomeUrl('?platforms=Android,,%20Tizen%20,').state).toEqual({
+			selectedPlatforms: ['Android', 'Tizen'],
+		})
+	})
+
+	test('drops a list param that holds nothing usable', () => {
+		expect(parseHomeUrl('?platforms=,,&hq=').state).toEqual({})
+	})
+
+	test('decodes platform names containing spaces', () => {
+		expect(parseHomeUrl('?platforms=Web+Browser,Fire+OS').state).toEqual({
+			selectedPlatforms: ['Web Browser', 'Fire OS'],
+		})
+	})
+
+	test('reads the page number', () => {
+		expect(parseHomeUrl('?page=3').page).toBe(3)
+	})
+
+	test('falls back to page 1 when the page is missing or unusable', () => {
+		expect(parseHomeUrl('').page).toBe(1)
+		expect(parseHomeUrl('?page=0').page).toBe(1)
+		expect(parseHomeUrl('?page=-2').page).toBe(1)
+		expect(parseHomeUrl('?page=abc').page).toBe(1)
+	})
+
+	test('ignores params it does not own', () => {
+		expect(parseHomeUrl('?utm_source=newsletter&ref=twitter').state).toEqual({})
+	})
+})
+
+describe('buildHomeUrl', () => {
+	test('writes nothing for an unfiltered homepage', () => {
+		expect(buildHomeUrl(homeState())).toBe('')
+	})
+
+	test('writes only the filters that are on', () => {
+		expect(buildHomeUrl(homeState({ showOpenSource: true }))).toBe('?openSource=true')
+	})
+
+	test('omits booleans that are off', () => {
+		const url = buildHomeUrl(homeState({ showFreeOnly: true, showProprietary: false }))
+		expect(url).toBe('?free=true')
+	})
+
+	test('writes the search term', () => {
+		expect(buildHomeUrl(homeState({ searchTerm: 'menu board' }))).toBe('?search=menu+board')
+	})
+
+	test('joins list filters with commas', () => {
+		const url = buildHomeUrl(homeState({ selectedPlatforms: ['Android', 'Tizen'] }))
+		expect(url).toBe('?platforms=Android%2CTizen')
+	})
+
+	test('omits empty list filters', () => {
+		expect(buildHomeUrl(homeState({ selectedPlatforms: [], selectedHQ: [] }))).toBe('')
+	})
+
+	test('writes the page only past the first', () => {
+		expect(buildHomeUrl(homeState(), 1)).toBe('')
+		expect(buildHomeUrl(homeState(), 2)).toBe('?page=2')
+	})
+
+	test('ignores state the homepage has no control for', () => {
+		const url = buildHomeUrl(homeState({ category: 'CMS', selectedCompliance: ['soc2'] }))
+		expect(url).toBe('')
+	})
+
+	test('carries through params it does not own', () => {
+		const url = buildHomeUrl(homeState({ showOpenSource: true }), 1, '?utm_source=newsletter')
+		expect(url).toBe('?utm_source=newsletter&openSource=true')
+	})
+
+	test('keeps foreign params even when no filter is active', () => {
+		expect(buildHomeUrl(homeState(), 1, '?utm_source=newsletter')).toBe('?utm_source=newsletter')
+	})
+
+	test('replaces stale values of params it owns rather than duplicating them', () => {
+		const url = buildHomeUrl(homeState({ showFreeOnly: true }), 1, '?openSource=true&free=true&page=7')
+		expect(url).toBe('?free=true')
+	})
+
+	test('combines filters into one shareable query', () => {
+		const url = buildHomeUrl(
+			homeState({
+				searchTerm: 'menu',
+				showOpenSource: true,
+				selectedPlatforms: ['Android'],
+				selectedHQ: ['usa'],
+			}),
+			2,
+		)
+		expect(url).toBe('?search=menu&openSource=true&platforms=Android&hq=usa&page=2')
+	})
+})
+
+describe('round trip', () => {
+	const cases: Array<[string, FilterState]> = [
+		['unfiltered', homeState()],
+		['search only', homeState({ searchTerm: 'digital menu' })],
+		[
+			'every boolean on',
+			homeState({
+				showOpenSource: true,
+				showProprietary: true,
+				showFreeOnly: true,
+				showFreeTrialOnly: true,
+				showFreemiumOnly: true,
+				showDiscontinuedOnly: true,
+				hideDiscontinued: true,
+				signupIsOpenOnly: true,
+			}),
+		],
+		['lists with spaces', homeState({ selectedPlatforms: ['Web Browser', 'Fire OS'], selectedHQ: ['united states'] })],
+		['mixed', homeState({ searchTerm: 'pi', showFreeOnly: true, selectedPlatforms: ['Raspberry Pi'] })],
+	]
+
+	for (const [name, state] of cases) {
+		test(`survives build then parse: ${name}`, () => {
+			const parsed = parseHomeUrl(buildHomeUrl(state))
+			expect(homeState(parsed.state)).toEqual(state)
+		})
+	}
+
+	test('keeps the page across a round trip', () => {
+		const state = homeState({ showOpenSource: true })
+		const parsed = parseHomeUrl(buildHomeUrl(state, 4))
+		expect(parsed.page).toBe(4)
+	})
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
 		"strict": true,
 		"skipLibCheck": true
 	},
-	"include": ["scripts/**/*.ts"]
+	"include": ["scripts/**/*.ts", "assets/ts/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Homepage filters now read from and write to the query string, so a filtered view can be shared or bookmarked. Previously only /products/ did this; the homepage returned early in `main.ts` before `initUrlSync` ran.

## Approach

New `assets/ts/home-url-sync.ts` rather than extending `url-sync.ts`, because the two pages start from different defaults. /products/ opens on the CMS category with both licence checkboxes ticked and always writes those params; the homepage opens with nothing selected. Only non-default values are written here, so an unfiltered homepage stays at `/` and a shared link carries exactly the filters that were turned on.

Params: `search`, `openSource`, `proprietary`, `free`, `freeTrial`, `freemium`, `discontinued`, `hideDiscontinued`, `signupIsOpenOnly`, `platforms`, `hq`, `page`. Names reuse the existing /products/ vocabulary where the filters overlap. Example: `/?free=true&platforms=Raspberry+Pi`.

The parse and build halves are pure functions with no DOM access, which is what the tests exercise. `initHomeUrlSync` does the wiring: restore state, tick the matching checkboxes and pills, then write back on every engine change via `replaceState`.

## Two things worth reviewing

Foreign params are preserved. The writer fires on the first `applyFilters()`, so without this a plain visit to `/?utm_source=newsletter` would immediately rewrite the address bar to `/` and drop the campaign tag. `buildHomeUrl` now carries through any param it does not own.

The product modal needed a small fix. It swaps the URL for the product's path while open, and captured `listUrl` once at page load. With filters in the URL that snapshot goes stale, so closing a modal would restore a pre-filter URL. `listUrl` is now captured at open time, and the URL writer skips while the pathname is not the list's, so filters never get stamped onto a product URL.

## Tests

30 tests in `tests/home-url-sync.test.ts` using `bun test`, no new dependencies. They cover parsing (booleans, comma lists, blank and malformed values, page bounds, unknown params), building (defaults omitted, encoding, foreign params preserved, stale owned params replaced), and build-then-parse round trips.

`bun test` added as a script; `tests/` added to the biome and tsconfig includes. `bun run lint` and `hugo --minify` both pass.